### PR TITLE
Fix misnamed latch enable pin on the 74373

### DIFF
--- a/src/main/dig/lib/74xx/flipflops/74373.dig
+++ b/src/main/dig/lib/74xx/flipflops/74373.dig
@@ -104,7 +104,7 @@
       <elementAttributes>
         <entry>
           <string>Label</string>
-          <string>CLK</string>
+          <string>C</string>
         </entry>
         <entry>
           <string>pinNumber</string>


### PR DESCRIPTION
The 74373 is a transparent latch and uses a latch enable signal instead of a clock pulse (as opposed to the 74374). TI conventions label this pin as C (http://www.ti.com/lit/ds/symlink/sn54s373.pdf -- see the + note under the package), while Motorola labels it as LE (https://ecee.colorado.edu/~mcclurel/sn74ls373rev5.pdf).