### PR TITLE
allow import "0xNNN..." format for memory data

### DIFF
--- a/src/main/java/de/neemann/digital/core/memory/DataField.java
+++ b/src/main/java/de/neemann/digital/core/memory/DataField.java
@@ -87,6 +87,8 @@ public class DataField implements HGSArray {
                     int p = line.indexOf('#');
                     if (p >= 0)
                         line = line.substring(0, p).trim();
+                    else if (line.startsWith("0x"))
+                        line = line.substring(2, line.length()).trim();
                     else
                         line = line.trim();
                     if (line.length() > 0) {


### PR DESCRIPTION
venus is a RISC-V instruction set simulator built for education. 

https://github.com/ThaumicMekanism/venus 
https://thaumicmekanism.github.io/venus/

and it can dump assembly instructions
```
li t0,1
li t1,2
add t2,t0,t1
```
 with hexadecimal format as follows form:
```
0x00100293
0x00200313
0x006283B3
```
it has a `0x` prefix compared to Digital's current ROM(or memory) format. 
If we support import of files in this format, then we do not need to manually remove the prefix of each line, which is very convenient.

The addition of this feature does not hurt any existing function.