### PR TITLE
allow import "0xNNN..." format for memory data

### DIFF
--- a/src/main/java/de/neemann/digital/core/memory/DataField.java
+++ b/src/main/java/de/neemann/digital/core/memory/DataField.java
@@ -87,6 +87,8 @@ public class DataField implements HGSArray {
                     int p = line.indexOf('#');
                     if (p >= 0)
                         line = line.substring(0, p).trim();
+                    else if (line.startsWith("0x"))
+                        line = line.substring(2).trim();
                     else
                         line = line.trim();
                     if (line.length() > 0) {

--- a/src/test/java/de/neemann/digital/core/memory/DataFieldTest.java
+++ b/src/test/java/de/neemann/digital/core/memory/DataFieldTest.java
@@ -60,4 +60,14 @@ public class DataFieldTest extends TestCase {
         assertEquals(0xAA, df.getDataWord(2));
         assertEquals(0xFF, df.getDataWord(3));
     }
+
+    public void testLoadHexPrefix() throws Exception {
+        String data = "v2.0 raw\n0x0\n0x10\n0xAA\n0xFF";
+        DataField df = new DataField(new StringReader(data));
+        assertEquals(4, df.size());
+        assertEquals(0x00, df.getDataWord(0));
+        assertEquals(0x10, df.getDataWord(1));
+        assertEquals(0xAA, df.getDataWord(2));
+        assertEquals(0xFF, df.getDataWord(3));
+    }
 }


### PR DESCRIPTION
venus is a RISC-V instruction set simulator built for education. 

https://github.com/ThaumicMekanism/venus 
https://thaumicmekanism.github.io/venus/

and it can dump assembly instructions
```
li t0,1
li t1,2
add t2,t0,t1
```
 with hexadecimal format as follows form:
```
0x00100293
0x00200313
0x006283B3
```
it has a `0x` prefix compared to Digital's current ROM(or memory) format. 
If we support import of files in this format, then we do not need to manually remove the prefix of each line, which is very convenient.

The addition of this feature does not hurt any existing function.