### PR TITLE
Implements Inverse 0/1 in Analyse|Synthesis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,13 @@ buildNumber.properties
 
 #netbeans project files
 nbactions.xml
+
+#Maven local directory
+.m2/
+
+#Java user prefereces folder
+.java/
+
+#Log files
+*Digital_*.log
+

--- a/src/main/java/de/neemann/digital/analyse/TruthTable.java
+++ b/src/main/java/de/neemann/digital/analyse/TruthTable.java
@@ -483,6 +483,19 @@ public class TruthTable {
     }
 
     /**
+     * Set all table entries to the inverse value.
+     * Only zeros and ones are processed. All other values are left intact
+     *
+     */
+    public void setAllValuesInverse() {
+        for (Result r : results) {
+            BoolTable bt = r.getValues();
+            if (bt instanceof BoolTableByteArray)
+                ((BoolTableByteArray) bt).setAllInverse();
+        }
+    }
+
+    /**
      * Sets additional data obtained from the model
      *
      * @param modelAnalyzerInfo the data obtained from the model

--- a/src/main/java/de/neemann/digital/analyse/quinemc/BoolTableByteArray.java
+++ b/src/main/java/de/neemann/digital/analyse/quinemc/BoolTableByteArray.java
@@ -98,4 +98,13 @@ public class BoolTableByteArray implements BoolTable {
         for (int i = 0; i < table.length; i++)
             table[i] = (byte) value;
     }
+
+    /**
+     * Sets all zero or one entries to their inverse value
+     */
+    public void setAllInverse() {
+        for (int i = 0; i < table.length; i++)
+            if (table[i] <= 1)
+            table[i] = (byte) (1 - table[i]);
+    }
 }

--- a/src/main/java/de/neemann/digital/gui/components/table/TableDialog.java
+++ b/src/main/java/de/neemann/digital/gui/components/table/TableDialog.java
@@ -397,12 +397,24 @@ public class TableDialog extends JDialog {
                 setAllValuesTo(1);
             }
         }.setToolTip(Lang.get("menu_table_setAllTo1_tt")).createJMenuItem());
+        setMenu.add(new ToolTipAction(Lang.get("menu_table_inverseAll01")) {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                setAllValuesInverse();
+            }
+        }.setToolTip(Lang.get("menu_table_inverseAll01_tt")).createJMenuItem());
         return setMenu;
     }
 
     private void setAllValuesTo(int value) {
         TruthTable t = model.getTable();
         t.setAllTo(value);
+        setModel(new TruthTableTableModel(t));
+    }
+
+    private void setAllValuesInverse() {
+        TruthTable t = model.getTable();
+        t.setAllValuesInverse();
         setModel(new TruthTableTableModel(t));
     }
 

--- a/src/main/resources/lang/lang_en.xml
+++ b/src/main/resources/lang/lang_en.xml
@@ -1548,6 +1548,8 @@
     <string name="menu_table_setAllTo0_tt">Set all values to zero.</string>
     <string name="menu_table_setAllTo1">Set all to 1</string>
     <string name="menu_table_setAllTo1_tt">Set all values to one.</string>
+    <string name="menu_table_inverseAll01">Inverse all 0/1</string>
+    <string name="menu_table_inverseAll01_tt">Change all 0 to 1, and all 1 to 0</string>
     <string name="menu_table_showAllSolutions">Show results dialog</string>
     <string name="menu_table_showAllSolutions_tt">Shows the results dialog again if it was closed manually.</string>
     <string name="menu_terminalDelete">Delete</string>


### PR DESCRIPTION
While analyzing a truth table and creating a circuit for an octal-to-7segment decoder I wanted to see if the result got better/smaller if I used a common cathode instead of a common anode display (which needs to have the low/high inputs reversed) I realized that there are no function to flip all output the bits in the truth table.

Even if I'm not a Java coder it was easy enough to implement such a functionality in Digital. I hope I followed the established coding standards enough here....

I didn't find any tests for the other related functions, and I'm not competent enough to implement them from scratch. So I didn't create any tests for this.