### PR TITLE
Implements CntProbe

### DIFF
--- a/src/main/dig/misc/CntProbe.dig
+++ b/src/main/dig/misc/CntProbe.dig
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="utf-8"?>
+<circuit>
+  <version>1</version>
+  <attributes/>
+  <visualElements>
+    <visualElement>
+      <elementName>CntProbe</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>Rising Counter Probe</string>
+        </entry>
+      </elementAttributes>
+      <pos x="500" y="160"/>
+    </visualElement>
+    <visualElement>
+      <elementName>LightBulb</elementName>
+      <elementAttributes/>
+      <pos x="480" y="180"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Ground</elementName>
+      <elementAttributes/>
+      <pos x="480" y="240"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Probe</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>Std Probe</string>
+        </entry>
+      </elementAttributes>
+      <pos x="500" y="100"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Button</elementName>
+      <elementAttributes/>
+      <pos x="440" y="160"/>
+    </visualElement>
+    <visualElement>
+      <elementName>CntProbe</elementName>
+      <elementAttributes>
+        <entry>
+          <string>edge</string>
+          <de.neemann.digital.core.io.CntProbe_-Edges>falling</de.neemann.digital.core.io.CntProbe_-Edges>
+        </entry>
+        <entry>
+          <string>Label</string>
+          <string>Falling Counter Probe</string>
+        </entry>
+      </elementAttributes>
+      <pos x="500" y="340"/>
+    </visualElement>
+    <visualElement>
+      <elementName>LightBulb</elementName>
+      <elementAttributes/>
+      <pos x="480" y="360"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Ground</elementName>
+      <elementAttributes/>
+      <pos x="480" y="420"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Probe</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>Std Probe</string>
+        </entry>
+      </elementAttributes>
+      <pos x="500" y="280"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Button</elementName>
+      <elementAttributes/>
+      <pos x="440" y="340"/>
+    </visualElement>
+    <visualElement>
+      <elementName>CntProbe</elementName>
+      <elementAttributes>
+        <entry>
+          <string>edge</string>
+          <de.neemann.digital.core.io.CntProbe_-Edges>both</de.neemann.digital.core.io.CntProbe_-Edges>
+        </entry>
+        <entry>
+          <string>Label</string>
+          <string>Both Counter Probe</string>
+        </entry>
+      </elementAttributes>
+      <pos x="500" y="540"/>
+    </visualElement>
+    <visualElement>
+      <elementName>LightBulb</elementName>
+      <elementAttributes/>
+      <pos x="480" y="560"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Ground</elementName>
+      <elementAttributes/>
+      <pos x="480" y="620"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Probe</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>Std Probe</string>
+        </entry>
+      </elementAttributes>
+      <pos x="500" y="480"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Button</elementName>
+      <elementAttributes/>
+      <pos x="440" y="540"/>
+    </visualElement>
+  </visualElements>
+  <wires>
+    <wire>
+      <p1 x="440" y="160"/>
+      <p2 x="480" y="160"/>
+    </wire>
+    <wire>
+      <p1 x="480" y="160"/>
+      <p2 x="500" y="160"/>
+    </wire>
+    <wire>
+      <p1 x="480" y="480"/>
+      <p2 x="500" y="480"/>
+    </wire>
+    <wire>
+      <p1 x="480" y="100"/>
+      <p2 x="500" y="100"/>
+    </wire>
+    <wire>
+      <p1 x="440" y="340"/>
+      <p2 x="480" y="340"/>
+    </wire>
+    <wire>
+      <p1 x="480" y="340"/>
+      <p2 x="500" y="340"/>
+    </wire>
+    <wire>
+      <p1 x="480" y="280"/>
+      <p2 x="500" y="280"/>
+    </wire>
+    <wire>
+      <p1 x="440" y="540"/>
+      <p2 x="480" y="540"/>
+    </wire>
+    <wire>
+      <p1 x="480" y="540"/>
+      <p2 x="500" y="540"/>
+    </wire>
+    <wire>
+      <p1 x="480" y="220"/>
+      <p2 x="480" y="240"/>
+    </wire>
+    <wire>
+      <p1 x="480" y="100"/>
+      <p2 x="480" y="160"/>
+    </wire>
+    <wire>
+      <p1 x="480" y="400"/>
+      <p2 x="480" y="420"/>
+    </wire>
+    <wire>
+      <p1 x="480" y="280"/>
+      <p2 x="480" y="340"/>
+    </wire>
+    <wire>
+      <p1 x="480" y="600"/>
+      <p2 x="480" y="620"/>
+    </wire>
+    <wire>
+      <p1 x="480" y="480"/>
+      <p2 x="480" y="540"/>
+    </wire>
+    <wire>
+      <p1 x="480" y="160"/>
+      <p2 x="480" y="180"/>
+    </wire>
+    <wire>
+      <p1 x="480" y="340"/>
+      <p2 x="480" y="360"/>
+    </wire>
+    <wire>
+      <p1 x="480" y="540"/>
+      <p2 x="480" y="560"/>
+    </wire>
+  </wires>
+  <measurementOrdering/>
+</circuit>

--- a/src/main/java/de/neemann/digital/builder/circuit/CircuitBuilder.java
+++ b/src/main/java/de/neemann/digital/builder/circuit/CircuitBuilder.java
@@ -20,6 +20,7 @@ import de.neemann.digital.core.io.Const;
 import de.neemann.digital.core.io.In;
 import de.neemann.digital.core.io.Out;
 import de.neemann.digital.core.io.Probe;
+import de.neemann.digital.core.io.CntProbe;
 import de.neemann.digital.core.memory.DataField;
 import de.neemann.digital.core.memory.LookUpTable;
 import de.neemann.digital.core.wiring.Clock;
@@ -572,6 +573,11 @@ public class CircuitBuilder implements BuilderInterface<CircuitBuilder> {
                 .setPos(new Vector(splitterXPos, y))
                 .setShapeFactory(shapeFactory));
         circuit.add(new VisualElement(Probe.DESCRIPTION.getName())
+                .setAttribute(Keys.LABEL, name)
+                .setAttribute(Keys.BITS, outputs.size())
+                .setPos(new Vector(splitterXPos + 3 * SIZE, y))
+                .setShapeFactory(shapeFactory));
+        circuit.add(new VisualElement(CntProbe.DESCRIPTION.getName())
                 .setAttribute(Keys.LABEL, name)
                 .setAttribute(Keys.BITS, outputs.size())
                 .setPos(new Vector(splitterXPos + 3 * SIZE, y))

--- a/src/main/java/de/neemann/digital/core/element/Keys.java
+++ b/src/main/java/de/neemann/digital/core/element/Keys.java
@@ -12,6 +12,7 @@ import de.neemann.digital.core.arithmetic.LeftRightFormat;
 import de.neemann.digital.core.extern.Application;
 import de.neemann.digital.core.io.CommonConnectionType;
 import de.neemann.digital.core.io.InValue;
+import de.neemann.digital.core.io.CntProbe;
 import de.neemann.digital.core.memory.DataField;
 import de.neemann.digital.core.memory.rom.ROMManger;
 import de.neemann.digital.draw.graphics.Orientation;
@@ -830,4 +831,10 @@ public final class Keys {
      */
     public static final Key<Boolean> SWITCH_ACTS_AS_INPUT =
             new Key<>("switchActsAsInput", false).setSecondary();
+
+    /**
+     * At which edge the CntProbe should act on
+     */
+   public static final Key<CntProbe.Edges> CNTPROBE_EDGE =
+           new Key.KeyEnum<>("edge", CntProbe.Edges.rising,  CntProbe.Edges.values());
 }

--- a/src/main/java/de/neemann/digital/core/io/CntProbe.java
+++ b/src/main/java/de/neemann/digital/core/io/CntProbe.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2016 Helmut Neemann, Mats Engstrom
+ * Use of this source code is governed by the GPL v3 license
+ * that can be found in the LICENSE file.
+ */
+package de.neemann.digital.core.io;
+
+import de.neemann.digital.core.*;
+import de.neemann.digital.core.element.Element;
+import de.neemann.digital.core.element.ElementAttributes;
+import de.neemann.digital.core.element.ElementTypeDescription;
+import de.neemann.digital.core.element.Keys;
+
+import static de.neemann.digital.core.element.PinInfo.input;
+
+/**
+ * The counting probe CntProbe
+ */
+public class CntProbe extends Node implements Element {
+
+    /**
+     * The possible edges
+     */
+    public enum Edges {
+    /**
+     * Trigger on the rising edge only
+     */
+    rising,
+
+    /**
+     * Trigger on the falling edge only
+     */
+    falling,
+
+    /**
+     * Trigger on both edges
+     */
+    both
+ }
+
+
+    /**
+     * The CntProbe description
+     */
+    public static final ElementTypeDescription DESCRIPTION
+            = new ElementTypeDescription("CntProbe", CntProbe.class,
+            input("in"))
+            .addAttribute(Keys.ROTATE)
+            .addAttribute(Keys.LABEL)
+            .addAttribute(Keys.CNTPROBE_EDGE);
+
+    private final String label;
+    private final Edges edge;
+    private ObservableValue value;
+    private boolean lastValue;
+    private int cnt;
+
+
+    /**
+     * Creates a new instance
+     *
+     * @param attributes the attributes
+     */
+    public CntProbe(ElementAttributes attributes) {
+        label = attributes.get(Keys.LABEL);
+        edge = attributes.get(Keys.CNTPROBE_EDGE);
+    }
+
+    @Override
+    public void setInputs(ObservableValues inputs) throws NodeException {
+        value = inputs.get(0).checkBits(1, null, 0).addObserverToValue(this);
+    }
+
+    @Override
+    public void readInputs() throws NodeException {
+        boolean nowValue=value.getBool();
+        if (nowValue != lastValue) {
+            if (
+                (edge==Edges.rising && nowValue)
+                || (edge==Edges.falling && !nowValue)
+                || (edge==Edges.both)
+               ) cnt++;
+        }
+        lastValue=nowValue;
+    }
+
+    @Override
+    public ObservableValues getOutputs() {
+        return ObservableValues.EMPTY_LIST;
+    }
+
+    @Override
+    public void writeOutputs() throws NodeException {
+    }
+
+    /**
+     * Returns the counts
+     *
+     * @return cnt
+     */
+    public int getCnt() {
+        return cnt;
+    }
+
+}

--- a/src/main/java/de/neemann/digital/draw/library/ElementLibrary.java
+++ b/src/main/java/de/neemann/digital/draw/library/ElementLibrary.java
@@ -129,6 +129,7 @@ public class ElementLibrary implements Iterable<ElementLibrary.ElementContainer>
                         .add(DipSwitch.DESCRIPTION)
                         .add(DummyElement.TEXTDESCRIPTION)
                         .add(Probe.DESCRIPTION)
+                        .add(CntProbe.DESCRIPTION)
                         .add(new LibraryNode(Lang.get("lib_more"))
                                 .add(RGBLED.DESCRIPTION)
                                 .add(Out.POLARITYAWARELEDDESCRIPTION)

--- a/src/main/java/de/neemann/digital/draw/shapes/CntProbeShape.java
+++ b/src/main/java/de/neemann/digital/draw/shapes/CntProbeShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Helmut Neemann
+ * Copyright (c) 2016 Helmut Neemann, Mats Engstrom
  * Use of this source code is governed by the GPL v3 license
  * that can be found in the LICENSE file.
  */
@@ -26,6 +26,7 @@ public class CntProbeShape implements Shape {
     private final PinDescriptions inputs;
     private final boolean isLabel;
     private CntProbe cntProbe;
+    private int cntValue;
 
     /**
      * Creates a new instance
@@ -46,9 +47,15 @@ public class CntProbeShape implements Shape {
     }
 
     @Override
-    public Interactor applyStateMonitor(IOState ioState, Observer guiObserver) {//        inValue = ioState.getInput(0);
+    public Interactor applyStateMonitor(IOState ioState, Observer guiObserver) {
         cntProbe = (CntProbe) ioState.getElement();
         return null;
+    }
+
+    @Override
+    public void readObservableValues() {
+        if (cntProbe != null)
+            cntValue = cntProbe.getCnt();
     }
 
     @Override
@@ -62,7 +69,7 @@ public class CntProbeShape implements Shape {
         }
         String v = "#";
         if (cntProbe != null)
-            v = Integer.toString(cntProbe.getCnt());
+            v = Integer.toString(cntValue);
         graphic.drawText(new Vector(2, dy), new Vector(3, dy), v, orientation, Style.NORMAL);
 
     }

--- a/src/main/java/de/neemann/digital/draw/shapes/CntProbeShape.java
+++ b/src/main/java/de/neemann/digital/draw/shapes/CntProbeShape.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2016 Helmut Neemann
+ * Use of this source code is governed by the GPL v3 license
+ * that can be found in the LICENSE file.
+ */
+package de.neemann.digital.draw.shapes;
+
+import de.neemann.digital.core.Observer;
+import de.neemann.digital.core.element.ElementAttributes;
+import de.neemann.digital.core.element.PinDescriptions;
+import de.neemann.digital.draw.elements.IOState;
+import de.neemann.digital.draw.elements.Pin;
+import de.neemann.digital.draw.elements.Pins;
+import de.neemann.digital.draw.graphics.Graphic;
+import de.neemann.digital.draw.graphics.Orientation;
+import de.neemann.digital.draw.graphics.Style;
+import de.neemann.digital.draw.graphics.Vector;
+import de.neemann.digital.core.io.CntProbe;
+
+/**
+ * The probe shape
+ */
+public class CntProbeShape implements Shape {
+
+    private final String label;
+    private final PinDescriptions inputs;
+    private final boolean isLabel;
+    private CntProbe cntProbe;
+
+    /**
+     * Creates a new instance
+     *
+     * @param attr    the attributes
+     * @param inputs  the inputs
+     * @param outputs the outputs
+     */
+    public CntProbeShape(ElementAttributes attr, PinDescriptions inputs, PinDescriptions outputs) {
+        this.inputs = inputs;
+        label = attr.getLabel();
+        isLabel = label != null && label.length() > 0;
+    }
+
+    @Override
+    public Pins getPins() {
+        return new Pins().add(new Pin(new Vector(0, 0), inputs.get(0)));
+    }
+
+    @Override
+    public Interactor applyStateMonitor(IOState ioState, Observer guiObserver) {//        inValue = ioState.getInput(0);
+        cntProbe = (CntProbe) ioState.getElement();
+        return null;
+    }
+
+    @Override
+    public void drawTo(Graphic graphic, Style highLight) {
+        int dy = -1;
+        Orientation orientation = Orientation.LEFTCENTER;
+        if (isLabel) {
+            graphic.drawText(new Vector(2, -4), new Vector(3, -4), label, Orientation.LEFTBOTTOM, Style.NORMAL);
+            dy = 4;
+            orientation = Orientation.LEFTTOP;
+        }
+        String v = "#";
+        if (cntProbe != null)
+            v = Integer.toString(cntProbe.getCnt());
+        graphic.drawText(new Vector(2, dy), new Vector(3, dy), v, orientation, Style.NORMAL);
+
+    }
+}

--- a/src/main/java/de/neemann/digital/draw/shapes/ShapeFactory.java
+++ b/src/main/java/de/neemann/digital/draw/shapes/ShapeFactory.java
@@ -112,6 +112,7 @@ public final class ShapeFactory {
         map.put(Button.DESCRIPTION.getName(), ButtonShape::new);
         map.put(ButtonLED.DESCRIPTION.getName(), ButtonLEDShape::new);
         map.put(Probe.DESCRIPTION.getName(), ProbeShape::new);
+        map.put(CntProbe.DESCRIPTION.getName(), CntProbeShape::new);
         map.put(Clock.DESCRIPTION.getName(), ClockShape::new);
         map.put(Out.SEVENDESCRIPTION.getName(), SevenSegShape::new);
         map.put(Out.SEVENHEXDESCRIPTION.getName(), SevenSegHexShape::new);

--- a/src/main/resources/lang/lang_en.xml
+++ b/src/main/resources/lang/lang_en.xml
@@ -198,7 +198,13 @@
         Does not affect the simulation.
     </string>
     <string name="elem_Probe_pin_in">The measurement value.</string>
-
+    <string name="elem_CntProbe">Counting Probe</string>
+    <string name="elem_CntProbe_tt">A probe that counts the number of edge transitions on a wire.</string>
+    <string name="key_edge">Edge</string>
+    <string name="key_edge_tt">At which edge should the probe count up at</string>
+    <string name="key_edge_rising">Rising</string>
+    <string name="key_edge_falling">Falling</string>
+    <string name="key_edge_both">Both</string>
 
     <!-- IO - more -->
 


### PR DESCRIPTION
I realized that I've got a lot of counters and probes for debugging setup all over the place in my PDP8 design. So I made this "counter probe" that can replace all of those.  Smaller and easer&faster to place where needed.

It took me a good 5-6 hours to figure out how to get this working - but it gave me a deeper insight on how Digital is designed so I consider it well spent time.  I'm starting to think that it's kinda fun to make components - hopefully it won't become an obsession. ^__^

<img width="396" alt="Screen Shot 2019-10-14 at 2 11 57 PM" src="https://user-images.githubusercontent.com/325326/66750453-cf2a5180-ee8c-11e9-97e3-66449968df7a.png">

Just to be perfectly clear - the "#" thingie at the bottom is the CntProbe, the top part is how I used to do it.

Please have a quick peek at it and see if I've messed up something somewhere.