### PR TITLE
Add bit separators in SingleValueDialog

### DIFF
--- a/src/main/java/de/neemann/digital/core/IntFormat.java
+++ b/src/main/java/de/neemann/digital/core/IntFormat.java
@@ -138,6 +138,11 @@ public enum IntFormat {
         public long dragValue(long initial, int bits, double inc) {
             return dragValueSigned(initial, bits, inc, false);
         }
+
+        @Override
+        public int[] getSeparatorsPositions(int bits) {
+            return createRegularSeparators(bits, 4);
+        }
     }
 
     private static long dragValueSigned(long initial, int bits, double inc, boolean signed) {
@@ -155,6 +160,17 @@ public enum IntFormat {
             min = 0;
         }
         return Math.max(min, Math.min(max, initial + Math.round(max * inc)));
+    }
+
+    /**
+     * Create regularly spaced array of separator positions for {@link ValueFormatter#getSeparatorsPositions(int)}.
+     */
+    private static int[] createRegularSeparators(int bits, int groupSize) {
+        int[] separators = new int[(bits - 1) / groupSize];
+        for (int i = 1; i <= separators.length; i++) {
+            separators[i - 1] = i * groupSize;
+        }
+        return separators;
     }
 
     /**
@@ -224,6 +240,11 @@ public enum IntFormat {
         public int strLen(int bits) {
             return (bits - 1) / 4 + 3;
         }
+
+        @Override
+        public int[] getSeparatorsPositions(int bits) {
+            return createRegularSeparators(bits, 4);
+        }
     }
 
     /**
@@ -289,6 +310,11 @@ public enum IntFormat {
             }
             return sb.toString();
         }
+
+        @Override
+        public int[] getSeparatorsPositions(int bits) {
+            return createRegularSeparators(bits, 3);
+        }
     }
 
     /**
@@ -320,6 +346,11 @@ public enum IntFormat {
             }
             return "0b" + new String(data);
         }
+
+        @Override
+        public int[] getSeparatorsPositions(int bits) {
+            return new int[]{};
+        }
     }
 
     /**
@@ -339,6 +370,11 @@ public enum IntFormat {
         @Override
         protected String format(Value value) {
             return "'" + ((char) value.getValue()) + "'";
+        }
+
+        @Override
+        public int[] getSeparatorsPositions(int bits) {
+            return new int[]{};
         }
     }
 
@@ -372,6 +408,11 @@ public enum IntFormat {
         @Override
         public long dragValue(long initial, int bits, double inc) {
             return dragValueSigned(initial, bits, inc, signed);
+        }
+
+        @Override
+        public int[] getSeparatorsPositions(int bits) {
+            return new int[]{};
         }
     }
 
@@ -447,6 +488,11 @@ public enum IntFormat {
         @Override
         public long dragValue(long initial, int bits, double inc) {
             return dragValueSigned(initial, bits, inc, signed);
+        }
+
+        @Override
+        public int[] getSeparatorsPositions(int bits) {
+            return new int[]{fixedPoint};
         }
     }
 
@@ -526,6 +572,15 @@ public enum IntFormat {
                 return Float.floatToIntBits((float) val);
             else
                 return Double.doubleToLongBits(val);
+        }
+
+        @Override
+        public int[] getSeparatorsPositions(int bits) {
+            if (bits == 32) {
+                return new int[]{23, 31};
+            } else {
+                return new int[]{52, 63};
+            }
         }
     }
 

--- a/src/main/java/de/neemann/digital/core/ValueFormatter.java
+++ b/src/main/java/de/neemann/digital/core/ValueFormatter.java
@@ -54,4 +54,13 @@ public interface ValueFormatter {
      * @return the modified value
      */
     long dragValue(long initial, int bits, double inc);
+
+    /**
+     * Get position of bits after which to add a separator when editing a value of this format.
+     * An empty array can be returned for no separators.
+     *
+     * @param bits the bits in value
+     * @return an array containing position of bits after which to add a separator.
+     */
+    int[] getSeparatorsPositions(int bits);
 }

--- a/src/main/java/de/neemann/digital/gui/components/SingleValueDialog.java
+++ b/src/main/java/de/neemann/digital/gui/components/SingleValueDialog.java
@@ -11,6 +11,7 @@ import de.neemann.digital.lang.Lang;
 import de.neemann.gui.Screen;
 
 import javax.swing.*;
+import javax.swing.border.Border;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
@@ -64,6 +65,7 @@ public final class SingleValueDialog extends JDialog implements ModelStateObserv
     private final SyncAccess syncAccess;
 
     private final JTextField textField;
+    private final Border separatorBorder;
     private boolean textIsModifying;
     private final boolean supportsHighZ;
     private final JComboBox<Format> formatComboBox;
@@ -101,7 +103,10 @@ public final class SingleValueDialog extends JDialog implements ModelStateObserv
             if (selectedItem != null)
                 valueFormatter = selectedItem.intFormat.createFormatter(null);
             setLongToDialog(editValue);
+            updateCheckBoxSeparators(editValue);
         });
+
+        separatorBorder = BorderFactory.createEmptyBorder(0, 0, 0, 5);
 
         JPanel checkBoxPanel = createCheckBoxPanel(editValue);
 
@@ -208,6 +213,21 @@ public final class SingleValueDialog extends JDialog implements ModelStateObserv
         return p;
     }
 
+    private void updateCheckBoxSeparators(Value value) {
+        int bits = value.getBits();
+        int[] separators = valueFormatter.getSeparatorsPositions(bits);
+        int currentSep = 0;
+        for (int i = 0; i < bits; i++) {
+            if (currentSep < separators.length && i == separators[currentSep]) {
+                checkBoxes[i].setBorder(separatorBorder);
+                currentSep++;
+            } else {
+                checkBoxes[i].setBorder(null);
+            }
+        }
+        pack();
+    }
+
     private void setBit(int bitNum, boolean set) {
         if (set)
             editValue = new Value(editValue.getValue() | 1L << bitNum, editValue.getBits());
@@ -234,6 +254,7 @@ public final class SingleValueDialog extends JDialog implements ModelStateObserv
         valueFormatter = format;
         formatComboBox.setSelectedItem(findFormat(valueFormatter));
         setLongToDialog(editValue);
+        updateCheckBoxSeparators(editValue);
         requestFocus();
         return this;
     }


### PR DESCRIPTION
Adds some separator space between bits of different digits for hexadecimal and octal, between parts of floating point values (sign, exponent, mantissa) and to separate the fractional part of fixed point values. It's a lot faster to find a specific bit this way.

![image](https://user-images.githubusercontent.com/33690959/106833084-eaf8ce80-6660-11eb-8320-196db0469938.png)
![image](https://user-images.githubusercontent.com/33690959/106833106-f8ae5400-6660-11eb-8a28-07152f55d277.png)
