### PR TITLE
Add search functionality to component tree view

### DIFF
--- a/src/main/java/de/neemann/digital/gui/components/tree/LibraryTreeModel.java
+++ b/src/main/java/de/neemann/digital/gui/components/tree/LibraryTreeModel.java
@@ -15,6 +15,7 @@ import javax.swing.tree.TreeModel;
 import javax.swing.tree.TreePath;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 
 /**
@@ -50,7 +51,8 @@ public class LibraryTreeModel implements TreeModel, LibraryListener {
 
     @Override
     public Object getRoot() {
-        return root;
+        Container c = getContainer(root);
+        return c.size() == 0 ? null : root;
     }
 
     @Override
@@ -109,6 +111,27 @@ public class LibraryTreeModel implements TreeModel, LibraryListener {
                     return c.node;
             c = getContainer(c.getChild(0));
         }
+    }
+
+    /**
+     * Check if any leaf node is visible in the tree.
+     *
+     * @param expandedNodes All currently expanded nodes.
+     * @return whether any leaf node is visible.
+     */
+    public boolean isAnyLeafNodeVisible(HashSet<LibraryNode> expandedNodes) {
+        return isAnyLeafNodeVisible(expandedNodes, root);
+    }
+
+    private boolean isAnyLeafNodeVisible(HashSet<LibraryNode> expandedNodes, LibraryNode node) {
+        if (node.isLeaf())
+            return true;
+        for (LibraryNode child : node) {
+            if (expandedNodes.contains(child) && isAnyLeafNodeVisible(expandedNodes, child)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private Container getContainer(LibraryNode libraryNode) {

--- a/src/main/java/de/neemann/digital/gui/components/tree/SelectSearch.java
+++ b/src/main/java/de/neemann/digital/gui/components/tree/SelectSearch.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2020 Helmut Neemann
+ * Use of this source code is governed by the GPL v3 license
+ * that can be found in the LICENSE file.
+ */
+
+package de.neemann.digital.gui.components.tree;
+
+import java.awt.*;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+
+import javax.swing.*;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.tree.TreePath;
+
+import de.neemann.digital.draw.library.ElementLibrary;
+import de.neemann.digital.lang.Lang;
+
+/**
+ * Search bar to filter components in tree.
+ */
+public class SelectSearch extends JTextField {
+
+    private static final int SEARCH_DEBOUNCE_DELAY = 100;
+
+    public SelectSearch(SelectTree tree, ElementLibrary library) {
+        super();
+
+        setBorder(BorderFactory.createEmptyBorder(8, 8, 8, 8));
+
+        Timer timer = new Timer(SEARCH_DEBOUNCE_DELAY, actionEvent -> {
+            LibraryTreeModel model = new LibraryTreeModel(library, node -> {
+                String query = getText().trim().toLowerCase();
+                return checkQueryMatch(query, node.getName()) ||
+                        checkQueryMatch(query, node.getTranslatedName());
+            });
+            tree.setModelAndRestoreExpansion(model);
+            if (!model.isAnyLeafNodeVisible(tree.getExpandedNodes()))
+                tree.expandPathTemporarily(new TreePath(model.getFirstLeafParent().getPath()));
+        });
+        timer.setRepeats(false);
+
+        getDocument().addDocumentListener(new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                filter();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                filter();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                filter();
+            }
+
+            private void filter() {
+                timer.restart();
+            }
+        });
+
+        addFocusListener(new FocusListener() {
+            @Override
+            public void focusGained(FocusEvent e) {
+                repaint();
+            }
+
+            @Override
+            public void focusLost(FocusEvent e) {
+                repaint();
+            }
+        });
+    }
+
+    private static boolean checkQueryMatch(String query, String text) {
+        // This could be improved to ignore diacritics in certain languages by using java.text.Normalizer.
+        return text.toLowerCase().contains(query);
+    }
+
+    @Override
+    public void paint(Graphics g) {
+        super.paint(g);
+        if (getText().isEmpty() && !hasFocus()) {
+            g.setColor(Color.GRAY);
+            g.drawString(Lang.get("key_search"), 5, (getHeight() + getFont().getSize()) / 2);
+        }
+    }
+}

--- a/src/main/java/de/neemann/digital/gui/components/tree/SelectTree.java
+++ b/src/main/java/de/neemann/digital/gui/components/tree/SelectTree.java
@@ -65,7 +65,7 @@ public class SelectTree extends JTree {
         setToolTipText("");
 
         // open first child
-        expandPath(new TreePath(model.getTypedRoot().getChild(0).getPath()));
+        expandPath(new TreePath(model.getFirstLeafParent().getPath()));
     }
 
     @Override

--- a/src/main/resources/lang/lang_en.xml
+++ b/src/main/resources/lang/lang_en.xml
@@ -1612,6 +1612,9 @@
     <string name="key_trigger_falling">falling edge</string>
     <string name="key_trigger_both">both edges</string>
 
+    <string name="key_search">Search</string>
+    <string name="key_search_noResults">No components found</string>
+
     <string name="key_colorScheme">Color scheme</string>
     <string name="key_colorScheme_DEFAULT">Normal</string>
     <string name="key_colorScheme_DARK">Dark</string>

--- a/src/test/java/de/neemann/digital/integration/TestInGUI.java
+++ b/src/test/java/de/neemann/digital/integration/TestInGUI.java
@@ -13,6 +13,7 @@ import de.neemann.digital.core.element.Keys;
 import de.neemann.digital.core.extern.External;
 import de.neemann.digital.core.io.In;
 import de.neemann.digital.core.io.Out;
+import de.neemann.digital.core.io.Probe;
 import de.neemann.digital.core.memory.ROM;
 import de.neemann.digital.core.wiring.Driver;
 import de.neemann.digital.draw.elements.Circuit;
@@ -169,7 +170,7 @@ public class TestInGUI extends TestCase {
         new GuiTester()
                 .delay(500)
                 .press("F5")
-                .mouseMove(100, 100)
+                .mouseMove(100, 150)
                 .delay(300)
                 .mouseClick(InputEvent.BUTTON1_DOWN_MASK)
                 .delay(200)
@@ -179,6 +180,30 @@ public class TestInGUI extends TestCase {
                 .add(new GuiTester.WindowCheck<>(Main.class, (gt, main) -> {
                     Circuit c = main.getCircuitComponent().getCircuit();
                     assertEquals(1, c.getElements().size());
+                }))
+                .execute();
+    }
+
+    public void testTreeViewSearch() {
+        new GuiTester()
+                .delay(500)
+                .press("F5")
+                .mouseMove(100, 75)
+                .delay(300)
+                .mouseClick(InputEvent.BUTTON1_DOWN_MASK)
+                .delay(200)
+                .type("probe")
+                .delay(200)
+                .mouseMove(100, 130)
+                .mouseClick(InputEvent.BUTTON1_DOWN_MASK)
+                .delay(200)
+                .mouseMove(400, 200)
+                .mouseClick(InputEvent.BUTTON1_DOWN_MASK)
+                .delay(500)
+                .add(new GuiTester.WindowCheck<>(Main.class, (gt, main) -> {
+                    Circuit c = main.getCircuitComponent().getCircuit();
+                    assertEquals(1, c.getElements().size());
+                    assertTrue(c.getElements().get(0).equalsDescription(Probe.DESCRIPTION));
                 }))
                 .execute();
     }


### PR DESCRIPTION
This one I wanted to submit for a while. It adds a search bar at the top of the component tree. 

There's a lot of components in Digital, and even more once you start having components in your library. It can also be difficult at first finding some components. I got tired a few months ago of constantly having to search for some components so I figured it was worthwhile adding this for myself. (where is Text again? Must be in Misc. along with Rectangle... no. In Wires perhaps? no. Oh right it's IO.)

There's a little more changes than in the last pull request, and again I'm not really sure the implementation is right. The main functionality comes from a new `filter` method in `LibraryNode` which creates a shallow copy but with only the children nodes matching the query. Most of `LibraryTreeModel` was changed.

A few notes:
- Search checks the built-in name and the localized name, but not the description.
- Search is debounced: entering a search query only takes effect some time afterwards (100 ms).
- If query produces no results a "no components found" text is shown.
- If the search query has results but none of the resulting tree nodes are expanded, the first node in the tree is expanded automatically. This is especially useful when searching for a specific component, so that it is immediately visible and accessible to the user after searching. This expansion however is temporary: making another query collapses the expanded node again. Nodes expanded by the user are never collapsed.
- There's a new GUI test.