### PR TITLE
Added initial support to export K-map to SVG

### DIFF
--- a/src/main/java/de/neemann/digital/draw/graphics/Graphic.java
+++ b/src/main/java/de/neemann/digital/draw/graphics/Graphic.java
@@ -51,6 +51,19 @@ public abstract class Graphic implements Closeable {
     public abstract void drawPolygon(Polygon p, Style style);
 
     /**
+     * Draws a round rect
+     *
+     * @param p1        upper left corner of the rectangle to draw
+     * @param width     width of the rectangle to draw
+     * @param height    height of the rectangle to draw
+     * @param arcWidth  the horizontal diameter of the arc at the four corners
+     * @param arcHeight the vertical diameter of the arc at the four corners
+     * @param style     the style
+     *
+     */
+    public abstract void drawRoundRect(VectorInterface p1, int width, int height, int arcWidth, int arcHeight, Style style);
+
+    /**
      * Draws a circle
      *
      * @param p1    upper left corner of outer rectangle containing the circle
@@ -124,6 +137,7 @@ public abstract class Graphic implements Closeable {
      *
      * @throws IOException IOException
      */
+    @Override
     public void close() throws IOException {
     }
 }

--- a/src/main/java/de/neemann/digital/draw/graphics/GraphicMinMax.java
+++ b/src/main/java/de/neemann/digital/draw/graphics/GraphicMinMax.java
@@ -5,12 +5,12 @@
  */
 package de.neemann.digital.draw.graphics;
 
-import de.neemann.digital.draw.graphics.text.formatter.GraphicsFormatter;
+import static de.neemann.digital.draw.graphics.GraphicSwing.getMirrorYOrientation;
 
 import java.awt.font.FontRenderContext;
 import java.awt.geom.Rectangle2D;
 
-import static de.neemann.digital.draw.graphics.GraphicSwing.getMirrorYOrientation;
+import de.neemann.digital.draw.graphics.text.formatter.GraphicsFormatter;
 
 /**
  * This class is used to determine the size of shapes or the whole circuit.
@@ -60,6 +60,10 @@ public class GraphicMinMax extends Graphic {
     @Override
     public void drawPolygon(Polygon p, Style style) {
         p.traverse(this::check);
+    }
+
+    @Override
+    public void drawRoundRect(VectorInterface p1, int width, int height, int arcWidth, int arcHeight, Style style) {
     }
 
     @Override

--- a/src/main/java/de/neemann/digital/draw/graphics/GraphicSVG.java
+++ b/src/main/java/de/neemann/digital/draw/graphics/GraphicSVG.java
@@ -5,15 +5,21 @@
  */
 package de.neemann.digital.draw.graphics;
 
-import de.neemann.digital.core.element.ElementAttributes;
+import static de.neemann.digital.draw.graphics.GraphicSwing.getMirrorYOrientation;
 
-import java.awt.*;
-import java.io.*;
+import java.awt.Color;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.HashSet;
 
-import static de.neemann.digital.draw.graphics.GraphicSwing.getMirrorYOrientation;
+import de.neemann.digital.core.element.ElementAttributes;
 
 /**
  * Used to create a SVG representation of the circuit.
@@ -150,6 +156,27 @@ public class GraphicSVG extends Graphic {
                 w.write(" fill-rule=\"evenodd\"");
 
             if (style.isFilled() && p.isClosed() && !isFlagSet(Flag.noShapeFilling))
+                w.write(" stroke=\"" + getColor(style) + "\" stroke-width=\"" + getStrokeWidth(style) + "\" fill=\"" + getColor(style) + "\" fill-opacity=\"" + getOpacity(style) + "\"/>\n");
+            else {
+                double strokeWidth = getStrokeWidth(style);
+                if (strokeWidth == 0)
+                    strokeWidth = getStrokeWidth(Style.THIN);
+                w.write(" stroke=\"" + getColor(style) + "\" stroke-width=\"" + strokeWidth + "\" fill=\"none\"/>\n");
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void drawRoundRect(VectorInterface p1, int width, int height, int arcWidth, int arcHeight, Style style) {
+        try {
+            w.write("<rect x=\"" + p1.getXFloat() + "\" y=\"" + p1.getYFloat()
+                    + "\" width=\"" + width + "\" height=\"" + height
+                    + "\" rx=\"" + arcWidth + "\" ry=\"" + arcHeight + "\"");
+            addStrokeDash(w, style.getDash());
+
+            if (style.isFilled() && !isFlagSet(Flag.noShapeFilling))
                 w.write(" stroke=\"" + getColor(style) + "\" stroke-width=\"" + getStrokeWidth(style) + "\" fill=\"" + getColor(style) + "\" fill-opacity=\"" + getOpacity(style) + "\"/>\n");
             else {
                 double strokeWidth = getStrokeWidth(style);

--- a/src/main/java/de/neemann/digital/draw/graphics/GraphicSwing.java
+++ b/src/main/java/de/neemann/digital/draw/graphics/GraphicSwing.java
@@ -5,12 +5,13 @@
  */
 package de.neemann.digital.draw.graphics;
 
-import de.neemann.digital.draw.graphics.text.formatter.GraphicsFormatter;
-
-import java.awt.*;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.GeneralPath;
 import java.awt.geom.Path2D;
+
+import de.neemann.digital.draw.graphics.text.formatter.GraphicsFormatter;
 
 /**
  * Used to draw on a {@link Graphics2D} instance.
@@ -89,6 +90,10 @@ public class GraphicSwing extends Graphic {
             gr.fill(path);
         if (style.getThickness() > 0)
             gr.draw(path);
+    }
+
+    @Override
+    public void drawRoundRect(VectorInterface p1, int width, int height, int arcWidth, int arcHeight, Style style) {
     }
 
     @Override

--- a/src/main/java/de/neemann/digital/draw/graphics/GraphicTransform.java
+++ b/src/main/java/de/neemann/digital/draw/graphics/GraphicTransform.java
@@ -35,6 +35,10 @@ public class GraphicTransform extends Graphic {
     }
 
     @Override
+    public void drawRoundRect(VectorInterface p1, int width, int height, int arcWidth, int arcHeight, Style style) {
+    }
+
+    @Override
     public void drawCircle(VectorInterface p1, VectorInterface p2, Style style) {
         parent.drawCircle(p1.transform(transform), p2.transform(transform), style);
     }

--- a/src/main/java/de/neemann/digital/draw/graphics/linemerger/GraphicLineCollector.java
+++ b/src/main/java/de/neemann/digital/draw/graphics/linemerger/GraphicLineCollector.java
@@ -5,11 +5,15 @@
  */
 package de.neemann.digital.draw.graphics.linemerger;
 
-import de.neemann.digital.draw.graphics.*;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+
+import de.neemann.digital.draw.graphics.Graphic;
+import de.neemann.digital.draw.graphics.Orientation;
+import de.neemann.digital.draw.graphics.Polygon;
+import de.neemann.digital.draw.graphics.Style;
+import de.neemann.digital.draw.graphics.VectorInterface;
 
 /**
  * Merges all single lines which are drawn to polygons.
@@ -38,6 +42,10 @@ public class GraphicLineCollector extends Graphic {
 
     @Override
     public void drawPolygon(Polygon p, Style style) {
+    }
+
+    @Override
+    public void drawRoundRect(VectorInterface p1, int width, int height, int arcWidth, int arcHeight, Style style) {
     }
 
     @Override

--- a/src/main/java/de/neemann/digital/draw/graphics/linemerger/GraphicSkipLines.java
+++ b/src/main/java/de/neemann/digital/draw/graphics/linemerger/GraphicSkipLines.java
@@ -5,7 +5,11 @@
  */
 package de.neemann.digital.draw.graphics.linemerger;
 
-import de.neemann.digital.draw.graphics.*;
+import de.neemann.digital.draw.graphics.Graphic;
+import de.neemann.digital.draw.graphics.Orientation;
+import de.neemann.digital.draw.graphics.Polygon;
+import de.neemann.digital.draw.graphics.Style;
+import de.neemann.digital.draw.graphics.VectorInterface;
 
 /**
  * Filters out all the lines.
@@ -32,6 +36,10 @@ public class GraphicSkipLines extends Graphic {
     @Override
     public void drawPolygon(Polygon p, Style style) {
         delegate.drawPolygon(p, style);
+    }
+
+    @Override
+    public void drawRoundRect(VectorInterface p1, int width, int height, int arcWidth, int arcHeight, Style style) {
     }
 
     @Override

--- a/src/main/java/de/neemann/digital/draw/graphics/text/formatter/GraphicsFormatter.java
+++ b/src/main/java/de/neemann/digital/draw/graphics/text/formatter/GraphicsFormatter.java
@@ -5,16 +5,25 @@
  */
 package de.neemann.digital.draw.graphics.text.formatter;
 
-import de.neemann.digital.analyse.expression.Expression;
-import de.neemann.digital.draw.graphics.text.text.ExpressionToText;
-import de.neemann.digital.draw.graphics.text.ParseException;
-import de.neemann.digital.draw.graphics.text.Parser;
-import de.neemann.digital.draw.graphics.text.text.Character;
-import de.neemann.digital.draw.graphics.text.text.*;
-
-import java.awt.*;
+import java.awt.BasicStroke;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
+import java.awt.Stroke;
 import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
+
+import de.neemann.digital.analyse.expression.Expression;
+import de.neemann.digital.draw.graphics.text.ParseException;
+import de.neemann.digital.draw.graphics.text.Parser;
+import de.neemann.digital.draw.graphics.text.text.Blank;
+import de.neemann.digital.draw.graphics.text.text.Character;
+import de.neemann.digital.draw.graphics.text.text.Decorate;
+import de.neemann.digital.draw.graphics.text.text.ExpressionToText;
+import de.neemann.digital.draw.graphics.text.text.Index;
+import de.neemann.digital.draw.graphics.text.text.Sentence;
+import de.neemann.digital.draw.graphics.text.text.Simple;
+import de.neemann.digital.draw.graphics.text.text.Text;
 
 /**
  * Formatter to draw a text on a {@link Graphics2D} instance.

--- a/src/test/java/de/neemann/digital/draw/graphics/linemerger/GraphicLineCollectorTest.java
+++ b/src/test/java/de/neemann/digital/draw/graphics/linemerger/GraphicLineCollectorTest.java
@@ -71,6 +71,10 @@ public class GraphicLineCollectorTest extends TestCase {
         public void drawPolygon(Polygon p, Style style) {
             poly.add(p);
         }
+        
+        @Override
+        public void drawRoundRect(VectorInterface p1, int width, int height, int arcWidth, int arcHeight, Style style) {
+        }
 
         @Override
         public void drawCircle(VectorInterface p1, VectorInterface p2, Style style) {


### PR DESCRIPTION
Added initial support to the K-Map diagram can be exported as an SVG graphic, according to the #618 issue. 