### PR TITLE
Add TCPport peripheral device

### DIFF
--- a/src/main/dig/misc/PortParallel.dig
+++ b/src/main/dig/misc/PortParallel.dig
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="utf-8"?>
+<circuit>
+  <version>1</version>
+  <attributes/>
+  <visualElements>
+    <visualElement>
+      <elementName>Clock</elementName>
+      <elementAttributes>
+        <entry>
+          <string>runRealTime</string>
+          <boolean>true</boolean>
+        </entry>
+        <entry>
+          <string>Frequency</string>
+          <int>100</int>
+        </entry>
+      </elementAttributes>
+      <pos x="440" y="120"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Keyboard</elementName>
+      <elementAttributes/>
+      <pos x="420" y="40"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Splitter</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Input Splitting</string>
+          <string>16</string>
+        </entry>
+        <entry>
+          <string>Output Splitting</string>
+          <string>0-7</string>
+        </entry>
+      </elementAttributes>
+      <pos x="520" y="40"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Const</elementName>
+      <elementAttributes/>
+      <pos x="400" y="60"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Probe</elementName>
+      <elementAttributes>
+        <entry>
+          <string>intFormat</string>
+          <intFormat>hex</intFormat>
+        </entry>
+      </elementAttributes>
+      <pos x="740" y="40"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Probe</elementName>
+      <elementAttributes/>
+      <pos x="740" y="60"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Probe</elementName>
+      <elementAttributes/>
+      <pos x="560" y="20"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Tunnel</elementName>
+      <elementAttributes>
+        <entry>
+          <string>NetName</string>
+          <string>CLK</string>
+        </entry>
+      </elementAttributes>
+      <pos x="460" y="120"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Tunnel</elementName>
+      <elementAttributes>
+        <entry>
+          <string>rotation</string>
+          <rotation rotation="2"/>
+        </entry>
+        <entry>
+          <string>NetName</string>
+          <string>CLK</string>
+        </entry>
+      </elementAttributes>
+      <pos x="620" y="60"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Tunnel</elementName>
+      <elementAttributes>
+        <entry>
+          <string>rotation</string>
+          <rotation rotation="2"/>
+        </entry>
+        <entry>
+          <string>NetName</string>
+          <string>CLK</string>
+        </entry>
+      </elementAttributes>
+      <pos x="400" y="40"/>
+    </visualElement>
+    <visualElement>
+      <elementName>In</elementName>
+      <elementAttributes/>
+      <pos x="600" y="100"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Probe</elementName>
+      <elementAttributes/>
+      <pos x="740" y="80"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Text</elementName>
+      <elementAttributes>
+        <entry>
+          <string>textFontSize</string>
+          <int>16</int>
+        </entry>
+        <entry>
+          <string>Description</string>
+          <string>Parallel port to TCP socket demonstration
+Connect telnet terminal to localhost port 2323</string>
+        </entry>
+      </elementAttributes>
+      <pos x="400" y="-40"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Text</elementName>
+      <elementAttributes>
+        <entry>
+          <string>textFontSize</string>
+          <int>16</int>
+        </entry>
+        <entry>
+          <string>Description</string>
+          <string>Characters typed at the local keyboard will be sent to 
+telnet. While sending the character the bsy will be set 
+for 100 clock cycles to simulate a slow external device.
+
+Characters from telnet will be shown at the Q pin, and 
+the avail will be set. The simulation must ack(nowledge) 
+the data before new data can be received.</string>
+        </entry>
+      </elementAttributes>
+      <pos x="800" y="0"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Port</elementName>
+      <elementAttributes>
+        <entry>
+          <string>portMode</string>
+          <de.neemann.digital.core.io.PortMode>parallel</de.neemann.digital.core.io.PortMode>
+        </entry>
+      </elementAttributes>
+      <pos x="640" y="40"/>
+    </visualElement>
+  </visualElements>
+  <wires>
+    <wire>
+      <p1 x="540" y="80"/>
+      <p2 x="640" y="80"/>
+    </wire>
+    <wire>
+      <p1 x="720" y="80"/>
+      <p2 x="740" y="80"/>
+    </wire>
+    <wire>
+      <p1 x="600" y="100"/>
+      <p2 x="640" y="100"/>
+    </wire>
+    <wire>
+      <p1 x="440" y="120"/>
+      <p2 x="460" y="120"/>
+    </wire>
+    <wire>
+      <p1 x="480" y="40"/>
+      <p2 x="520" y="40"/>
+    </wire>
+    <wire>
+      <p1 x="400" y="40"/>
+      <p2 x="420" y="40"/>
+    </wire>
+    <wire>
+      <p1 x="720" y="40"/>
+      <p2 x="740" y="40"/>
+    </wire>
+    <wire>
+      <p1 x="540" y="40"/>
+      <p2 x="560" y="40"/>
+    </wire>
+    <wire>
+      <p1 x="560" y="40"/>
+      <p2 x="640" y="40"/>
+    </wire>
+    <wire>
+      <p1 x="400" y="60"/>
+      <p2 x="420" y="60"/>
+    </wire>
+    <wire>
+      <p1 x="720" y="60"/>
+      <p2 x="740" y="60"/>
+    </wire>
+    <wire>
+      <p1 x="620" y="60"/>
+      <p2 x="640" y="60"/>
+    </wire>
+    <wire>
+      <p1 x="480" y="60"/>
+      <p2 x="540" y="60"/>
+    </wire>
+    <wire>
+      <p1 x="560" y="20"/>
+      <p2 x="560" y="40"/>
+    </wire>
+    <wire>
+      <p1 x="540" y="60"/>
+      <p2 x="540" y="80"/>
+    </wire>
+  </wires>
+  <measurementOrdering/>
+</circuit>

--- a/src/main/dig/misc/PortSerial.dig
+++ b/src/main/dig/misc/PortSerial.dig
@@ -1,0 +1,628 @@
+<?xml version="1.0" encoding="utf-8"?>
+<circuit>
+  <version>1</version>
+  <attributes/>
+  <visualElements>
+    <visualElement>
+      <elementName>Counter</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Bits</string>
+          <int>8</int>
+        </entry>
+      </elementAttributes>
+      <pos x="-20" y="-20"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Const</elementName>
+      <elementAttributes/>
+      <pos x="-40" y="-20"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Clock</elementName>
+      <elementAttributes>
+        <entry>
+          <string>runRealTime</string>
+          <boolean>true</boolean>
+        </entry>
+        <entry>
+          <string>Frequency</string>
+          <int>192</int>
+        </entry>
+      </elementAttributes>
+      <pos x="-100" y="200"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Multiplexer</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Selector Bits</string>
+          <int>4</int>
+        </entry>
+        <entry>
+          <string>flipSelPos</string>
+          <boolean>true</boolean>
+        </entry>
+      </elementAttributes>
+      <pos x="380" y="0"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Const</elementName>
+      <elementAttributes/>
+      <pos x="340" y="0"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Const</elementName>
+      <elementAttributes/>
+      <pos x="360" y="200"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Splitter</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Input Splitting</string>
+          <string>8</string>
+        </entry>
+        <entry>
+          <string>Output Splitting</string>
+          <string>1*8</string>
+        </entry>
+      </elementAttributes>
+      <pos x="340" y="40"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Const</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Value</string>
+          <long>0</long>
+        </entry>
+      </elementAttributes>
+      <pos x="340" y="20"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Splitter</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Input Splitting</string>
+          <string>8</string>
+        </entry>
+        <entry>
+          <string>Output Splitting</string>
+          <string>4-7</string>
+        </entry>
+      </elementAttributes>
+      <pos x="60" y="-20"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Keyboard</elementName>
+      <elementAttributes/>
+      <pos x="0" y="100"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Splitter</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Input Splitting</string>
+          <string>16</string>
+        </entry>
+      </elementAttributes>
+      <pos x="100" y="100"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Port</elementName>
+      <elementAttributes/>
+      <pos x="620" y="140"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Text</elementName>
+      <elementAttributes>
+        <entry>
+          <string>textFontSize</string>
+          <int>16</int>
+        </entry>
+        <entry>
+          <string>textOrientation</string>
+          <de.neemann.digital.draw.graphics.Orientation>RIGHTCENTER</de.neemann.digital.draw.graphics.Orientation>
+        </entry>
+        <entry>
+          <string>Description</string>
+          <string>Idle</string>
+        </entry>
+      </elementAttributes>
+      <pos x="320" y="0"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Text</elementName>
+      <elementAttributes>
+        <entry>
+          <string>textFontSize</string>
+          <int>16</int>
+        </entry>
+        <entry>
+          <string>textOrientation</string>
+          <de.neemann.digital.draw.graphics.Orientation>RIGHTCENTER</de.neemann.digital.draw.graphics.Orientation>
+        </entry>
+        <entry>
+          <string>Description</string>
+          <string>Startbit</string>
+        </entry>
+      </elementAttributes>
+      <pos x="320" y="20"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Text</elementName>
+      <elementAttributes>
+        <entry>
+          <string>textFontSize</string>
+          <int>16</int>
+        </entry>
+        <entry>
+          <string>textOrientation</string>
+          <de.neemann.digital.draw.graphics.Orientation>RIGHTCENTER</de.neemann.digital.draw.graphics.Orientation>
+        </entry>
+        <entry>
+          <string>Description</string>
+          <string>Stopbit</string>
+        </entry>
+      </elementAttributes>
+      <pos x="340" y="200"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Text</elementName>
+      <elementAttributes>
+        <entry>
+          <string>textFontSize</string>
+          <int>16</int>
+        </entry>
+        <entry>
+          <string>textOrientation</string>
+          <de.neemann.digital.draw.graphics.Orientation>RIGHTCENTER</de.neemann.digital.draw.graphics.Orientation>
+        </entry>
+        <entry>
+          <string>Description</string>
+          <string>Unused</string>
+        </entry>
+      </elementAttributes>
+      <pos x="340" y="260"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Tunnel</elementName>
+      <elementAttributes>
+        <entry>
+          <string>NetName</string>
+          <string>CLK</string>
+        </entry>
+      </elementAttributes>
+      <pos x="-80" y="200"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Tunnel</elementName>
+      <elementAttributes>
+        <entry>
+          <string>rotation</string>
+          <rotation rotation="2"/>
+        </entry>
+        <entry>
+          <string>NetName</string>
+          <string>CLK</string>
+        </entry>
+      </elementAttributes>
+      <pos x="-40" y="0"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Tunnel</elementName>
+      <elementAttributes>
+        <entry>
+          <string>rotation</string>
+          <rotation rotation="2"/>
+        </entry>
+        <entry>
+          <string>NetName</string>
+          <string>CLK</string>
+        </entry>
+      </elementAttributes>
+      <pos x="600" y="180"/>
+    </visualElement>
+    <visualElement>
+      <elementName>LED</elementName>
+      <elementAttributes>
+        <entry>
+          <string>rotation</string>
+          <rotation rotation="1"/>
+        </entry>
+      </elementAttributes>
+      <pos x="460" y="140"/>
+    </visualElement>
+    <visualElement>
+      <elementName>LED</elementName>
+      <elementAttributes/>
+      <pos x="740" y="160"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Const</elementName>
+      <elementAttributes/>
+      <pos x="340" y="300"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Comparator</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Bits</string>
+          <int>4</int>
+        </entry>
+      </elementAttributes>
+      <pos x="140" y="-80"/>
+    </visualElement>
+    <visualElement>
+      <elementName>RS_FF_AS</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Default</string>
+          <long>1</long>
+        </entry>
+      </elementAttributes>
+      <pos x="-140" y="20"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Const</elementName>
+      <elementAttributes/>
+      <pos x="-20" y="120"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Const</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Value</string>
+          <long>11</long>
+        </entry>
+        <entry>
+          <string>Bits</string>
+          <int>4</int>
+        </entry>
+        <entry>
+          <string>intFormat</string>
+          <intFormat>dec</intFormat>
+        </entry>
+      </elementAttributes>
+      <pos x="120" y="-80"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Probe</elementName>
+      <elementAttributes>
+        <entry>
+          <string>intFormat</string>
+          <intFormat>dec</intFormat>
+        </entry>
+      </elementAttributes>
+      <pos x="420" y="-20"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Text</elementName>
+      <elementAttributes>
+        <entry>
+          <string>textFontSize</string>
+          <int>16</int>
+        </entry>
+        <entry>
+          <string>Description</string>
+          <string>Serial port to TCP socket demonstration
+Connect telnet terminal to localhost port 2323</string>
+        </entry>
+      </elementAttributes>
+      <pos x="-140" y="-200"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Text</elementName>
+      <elementAttributes>
+        <entry>
+          <string>textFontSize</string>
+          <int>16</int>
+        </entry>
+        <entry>
+          <string>Description</string>
+          <string>Characters typed at the local keyboard (first converted
+into a serial stream) enters the PORT component (in) and 
+is sent to the telnet via the socket. 
+
+Characters from telnet will be output as a 8N2 serial stream 
+at the (out) pin. But also fed back to the receiver so it will be 
+echoed back to the telnet.</string>
+        </entry>
+      </elementAttributes>
+      <pos x="300" y="-200"/>
+    </visualElement>
+    <visualElement>
+      <elementName>And</elementName>
+      <elementAttributes/>
+      <pos x="520" y="120"/>
+    </visualElement>
+    <visualElement>
+      <elementName>D_FF</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Bits</string>
+          <int>8</int>
+        </entry>
+      </elementAttributes>
+      <pos x="160" y="100"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Probe</elementName>
+      <elementAttributes>
+        <entry>
+          <string>intFormat</string>
+          <intFormat>ascii</intFormat>
+        </entry>
+      </elementAttributes>
+      <pos x="240" y="80"/>
+    </visualElement>
+  </visualElements>
+  <wires>
+    <wire>
+      <p1 x="340" y="0"/>
+      <p2 x="380" y="0"/>
+    </wire>
+    <wire>
+      <p1 x="-40" y="0"/>
+      <p2 x="-20" y="0"/>
+    </wire>
+    <wire>
+      <p1 x="360" y="160"/>
+      <p2 x="380" y="160"/>
+    </wire>
+    <wire>
+      <p1 x="-160" y="160"/>
+      <p2 x="-40" y="160"/>
+    </wire>
+    <wire>
+      <p1 x="700" y="160"/>
+      <p2 x="720" y="160"/>
+    </wire>
+    <wire>
+      <p1 x="420" y="160"/>
+      <p2 x="460" y="160"/>
+    </wire>
+    <wire>
+      <p1 x="720" y="160"/>
+      <p2 x="740" y="160"/>
+    </wire>
+    <wire>
+      <p1 x="460" y="160"/>
+      <p2 x="520" y="160"/>
+    </wire>
+    <wire>
+      <p1 x="-40" y="160"/>
+      <p2 x="80" y="160"/>
+    </wire>
+    <wire>
+      <p1 x="360" y="100"/>
+      <p2 x="380" y="100"/>
+    </wire>
+    <wire>
+      <p1 x="60" y="100"/>
+      <p2 x="100" y="100"/>
+    </wire>
+    <wire>
+      <p1 x="120" y="100"/>
+      <p2 x="160" y="100"/>
+    </wire>
+    <wire>
+      <p1 x="220" y="100"/>
+      <p2 x="240" y="100"/>
+    </wire>
+    <wire>
+      <p1 x="-40" y="100"/>
+      <p2 x="0" y="100"/>
+    </wire>
+    <wire>
+      <p1 x="240" y="100"/>
+      <p2 x="320" y="100"/>
+    </wire>
+    <wire>
+      <p1 x="360" y="260"/>
+      <p2 x="380" y="260"/>
+    </wire>
+    <wire>
+      <p1 x="-160" y="40"/>
+      <p2 x="-140" y="40"/>
+    </wire>
+    <wire>
+      <p1 x="360" y="40"/>
+      <p2 x="380" y="40"/>
+    </wire>
+    <wire>
+      <p1 x="320" y="40"/>
+      <p2 x="340" y="40"/>
+    </wire>
+    <wire>
+      <p1 x="360" y="200"/>
+      <p2 x="380" y="200"/>
+    </wire>
+    <wire>
+      <p1 x="-100" y="200"/>
+      <p2 x="-80" y="200"/>
+    </wire>
+    <wire>
+      <p1 x="340" y="300"/>
+      <p2 x="360" y="300"/>
+    </wire>
+    <wire>
+      <p1 x="360" y="300"/>
+      <p2 x="380" y="300"/>
+    </wire>
+    <wire>
+      <p1 x="360" y="140"/>
+      <p2 x="380" y="140"/>
+    </wire>
+    <wire>
+      <p1 x="580" y="140"/>
+      <p2 x="620" y="140"/>
+    </wire>
+    <wire>
+      <p1 x="120" y="-80"/>
+      <p2 x="140" y="-80"/>
+    </wire>
+    <wire>
+      <p1 x="360" y="80"/>
+      <p2 x="380" y="80"/>
+    </wire>
+    <wire>
+      <p1 x="500" y="80"/>
+      <p2 x="720" y="80"/>
+    </wire>
+    <wire>
+      <p1 x="360" y="240"/>
+      <p2 x="380" y="240"/>
+    </wire>
+    <wire>
+      <p1 x="-40" y="-20"/>
+      <p2 x="-20" y="-20"/>
+    </wire>
+    <wire>
+      <p1 x="40" y="-20"/>
+      <p2 x="60" y="-20"/>
+    </wire>
+    <wire>
+      <p1 x="80" y="-20"/>
+      <p2 x="120" y="-20"/>
+    </wire>
+    <wire>
+      <p1 x="400" y="-20"/>
+      <p2 x="420" y="-20"/>
+    </wire>
+    <wire>
+      <p1 x="120" y="-20"/>
+      <p2 x="400" y="-20"/>
+    </wire>
+    <wire>
+      <p1 x="600" y="180"/>
+      <p2 x="620" y="180"/>
+    </wire>
+    <wire>
+      <p1 x="360" y="180"/>
+      <p2 x="380" y="180"/>
+    </wire>
+    <wire>
+      <p1 x="340" y="20"/>
+      <p2 x="380" y="20"/>
+    </wire>
+    <wire>
+      <p1 x="-80" y="20"/>
+      <p2 x="-20" y="20"/>
+    </wire>
+    <wire>
+      <p1 x="-160" y="20"/>
+      <p2 x="-140" y="20"/>
+    </wire>
+    <wire>
+      <p1 x="-160" y="-120"/>
+      <p2 x="220" y="-120"/>
+    </wire>
+    <wire>
+      <p1 x="60" y="120"/>
+      <p2 x="80" y="120"/>
+    </wire>
+    <wire>
+      <p1 x="-20" y="120"/>
+      <p2 x="0" y="120"/>
+    </wire>
+    <wire>
+      <p1 x="360" y="120"/>
+      <p2 x="380" y="120"/>
+    </wire>
+    <wire>
+      <p1 x="500" y="120"/>
+      <p2 x="520" y="120"/>
+    </wire>
+    <wire>
+      <p1 x="80" y="120"/>
+      <p2 x="160" y="120"/>
+    </wire>
+    <wire>
+      <p1 x="360" y="280"/>
+      <p2 x="380" y="280"/>
+    </wire>
+    <wire>
+      <p1 x="200" y="-60"/>
+      <p2 x="220" y="-60"/>
+    </wire>
+    <wire>
+      <p1 x="120" y="-60"/>
+      <p2 x="140" y="-60"/>
+    </wire>
+    <wire>
+      <p1 x="360" y="60"/>
+      <p2 x="380" y="60"/>
+    </wire>
+    <wire>
+      <p1 x="360" y="220"/>
+      <p2 x="380" y="220"/>
+    </wire>
+    <wire>
+      <p1 x="240" y="80"/>
+      <p2 x="240" y="100"/>
+    </wire>
+    <wire>
+      <p1 x="80" y="120"/>
+      <p2 x="80" y="160"/>
+    </wire>
+    <wire>
+      <p1 x="720" y="80"/>
+      <p2 x="720" y="160"/>
+    </wire>
+    <wire>
+      <p1 x="400" y="-20"/>
+      <p2 x="400" y="0"/>
+    </wire>
+    <wire>
+      <p1 x="320" y="40"/>
+      <p2 x="320" y="100"/>
+    </wire>
+    <wire>
+      <p1 x="500" y="80"/>
+      <p2 x="500" y="120"/>
+    </wire>
+    <wire>
+      <p1 x="-40" y="100"/>
+      <p2 x="-40" y="160"/>
+    </wire>
+    <wire>
+      <p1 x="360" y="220"/>
+      <p2 x="360" y="240"/>
+    </wire>
+    <wire>
+      <p1 x="360" y="240"/>
+      <p2 x="360" y="260"/>
+    </wire>
+    <wire>
+      <p1 x="360" y="260"/>
+      <p2 x="360" y="280"/>
+    </wire>
+    <wire>
+      <p1 x="360" y="280"/>
+      <p2 x="360" y="300"/>
+    </wire>
+    <wire>
+      <p1 x="120" y="-60"/>
+      <p2 x="120" y="-20"/>
+    </wire>
+    <wire>
+      <p1 x="460" y="140"/>
+      <p2 x="460" y="160"/>
+    </wire>
+    <wire>
+      <p1 x="220" y="-120"/>
+      <p2 x="220" y="-60"/>
+    </wire>
+    <wire>
+      <p1 x="-160" y="40"/>
+      <p2 x="-160" y="160"/>
+    </wire>
+    <wire>
+      <p1 x="-160" y="-120"/>
+      <p2 x="-160" y="20"/>
+    </wire>
+  </wires>
+  <measurementOrdering/>
+</circuit>

--- a/src/main/java/de/neemann/digital/core/element/Keys.java
+++ b/src/main/java/de/neemann/digital/core/element/Keys.java
@@ -12,6 +12,7 @@ import de.neemann.digital.core.arithmetic.LeftRightFormat;
 import de.neemann.digital.core.extern.Application;
 import de.neemann.digital.core.io.CommonConnectionType;
 import de.neemann.digital.core.io.InValue;
+import de.neemann.digital.core.io.PortMode;
 import de.neemann.digital.core.memory.DataField;
 import de.neemann.digital.core.memory.rom.ROMManger;
 import de.neemann.digital.draw.graphics.Orientation;
@@ -906,5 +907,17 @@ public final class Keys {
     public static final Key.KeyEnum<ScopeTrigger.Trigger> TRIGGER =
             new Key.KeyEnum<>("trigger", ScopeTrigger.Trigger.both, ScopeTrigger.Trigger.values());
 
+    /**
+     * true if port is to be used with telnet
+     */
+    public static final Key<Boolean> PORT_TELNET =
+            new Key<>("portTelnet", true);
+
+
+   /**
+     * type of Port (serial/parallel)
+     */
+    public static final Key<PortMode> PORT_MODE =
+            new Key.KeyEnum<>("portMode", PortMode.serial, PortMode.values());
 
 }

--- a/src/main/java/de/neemann/digital/core/io/Port.java
+++ b/src/main/java/de/neemann/digital/core/io/Port.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright (c) 2019 Helmut Neemann & Mats Engstrom.
+ * Use of this source code is governed by the GPL v3 license
+ * that can be found in the LICENSE file.
+ */
+package de.neemann.digital.core.io;
+
+import de.neemann.digital.core.*;
+import de.neemann.digital.core.element.*;
+import de.neemann.digital.core.Node;
+import de.neemann.digital.core.NodeException;
+import de.neemann.digital.core.ObservableValue;
+import de.neemann.digital.core.ObservableValues;
+import de.neemann.digital.core.element.Element;
+import de.neemann.digital.core.element.ElementAttributes;
+import de.neemann.digital.core.element.ElementTypeDescription;
+import de.neemann.digital.core.element.Keys;
+
+import java.io.DataOutputStream;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+import static de.neemann.digital.core.element.PinInfo.input;
+
+/**
+ * The Port component.
+ */
+public class Port extends Node implements Element {
+
+    /**
+     * The Port description
+     */
+    public static final ElementTypeDescription DESCRIPTION
+        = new ElementTypeDescription(Port.class) {
+        public PinDescriptions getInputDescription(ElementAttributes elementAttributes) throws NodeException {
+            if (elementAttributes.get(Keys.PORT_MODE)==PortMode.serial)
+                return new PinDescriptions(
+                    // Serial
+                    input("in"),
+                    input("C").setClock()).setLangKey(getPinLangKey());
+            else
+                return new PinDescriptions(
+                    // Parallel
+                    input("D"),
+                    input("C").setClock(),
+                    input("stb"),
+                    input("ack")).setLangKey(getPinLangKey());
+        }
+    }
+    .addAttribute(Keys.ROTATE)
+    .addAttribute(Keys.LABEL)
+    .addAttribute(Keys.INVERTER_CONFIG)
+    .addAttribute(Keys.PORT_MODE)
+    .addAttribute(Keys.PORT_TELNET);
+
+    private final String label;
+    private ObservableValue clock;
+    private ObservableValue sin;    // Serial input
+    private ObservableValue sout;   // Serial output
+    private ObservableValue pin;    // Parallel input (D)
+    private ObservableValue pout;   // Parallel output (Q)
+    private ObservableValue stb;    // Strobe for parallel input data
+    private ObservableValue bsy;    // Busy processing parallel input data
+    private ObservableValue avail;  // Parallel output data available at Q
+    private ObservableValue ack;    // Acknowledge that data is read from Q
+
+    private PortMode portMode;       // serial/parallel
+    private boolean portTelnet;      // false=raw, true=telnet
+    private boolean lastClock = false;
+    private int bsyTicks = 0;
+    private long pinVal = 0;
+    private long poutVal = 0;
+    private long availVal = 0;
+    private long bsyVal = 0;
+    private long soutVal=1;     // The serial output should idle high
+
+    private boolean lastStb = false;
+    private boolean lastAck = false;
+
+    private static final int  OVERSAMPLECNT = 16;
+    private static final int  BITS_TO_COLLECT = 1+8+1; // 1 start, 8 data, 1 stop
+    private int rxTicks = 0;    // Keeps track of the incoming baud/bitrate clock
+    private int txTicks = 0;    // Keeps track of the incoming baud/bitrate clock
+    private int txData = 0;     // Bit pattern (including start/stop bits to be sent)
+    private int rxData=0;       // Collects bits from sin-input into a byte
+    private int rxBitCnt=0;     // How many bits remanining to be collected
+    private boolean waitForStartbit=true;
+
+    static private Deque<Integer> buf = new ArrayDeque<Integer>(1000);
+    static private PortSocket portSocket = null;
+
+
+    /**
+     * Creates a new instance
+     *
+     * @param attributes the elements attributes
+     */
+    public Port(ElementAttributes attributes) {
+        portMode = attributes.get(Keys.PORT_MODE);
+        portTelnet = attributes.get(Keys.PORT_TELNET);
+        label = attributes.getLabel();
+
+        if (portMode==PortMode.serial) { // Serial mode
+            sout = new ObservableValue("out", 1).setPinDescription(DESCRIPTION);
+        } else {        // Parallel mode
+            pout = new ObservableValue("Q", 8).setPinDescription(DESCRIPTION);
+            bsy = new ObservableValue("bsy", 1).setPinDescription(DESCRIPTION);
+            avail = new ObservableValue("avail", 1).setPinDescription(DESCRIPTION);
+        }
+
+        // Create a socket listener thread if we don't already have one
+        if (portSocket == null) {
+            portSocket = new PortSocket(this, 2323, portTelnet);
+            portSocket.start();
+        }
+    }
+
+    /**
+     *
+     */
+    @Override
+    public void setInputs(ObservableValues inputs) throws NodeException {
+        if (portMode==PortMode.serial) {
+            // Serial
+            sin = inputs.get(0).addObserverToValue(this).checkBits(1, this, 0);
+            clock = inputs.get(1).addObserverToValue(this).checkBits(1, this, 1);
+        } else {
+            // Parallel
+            pin = inputs.get(0).addObserverToValue(this).checkBits(8, this, 0);
+            clock = inputs.get(1).addObserverToValue(this).checkBits(1, this, 1);
+            stb = inputs.get(2).addObserverToValue(this).checkBits(1, this, 2);
+            ack = inputs.get(3).addObserverToValue(this).checkBits(1, this, 3);
+        }
+    }
+
+    @Override
+    public ObservableValues getOutputs() {
+        if (portMode==PortMode.serial) {
+            return new ObservableValues(sout);              // Serial
+        } else {
+            return new ObservableValues(pout, bsy, avail);  // Parallel
+        }
+    }
+
+    @Override
+    public void readInputs() throws NodeException {
+        boolean nowClock = clock.getBool();
+        boolean rising=(lastClock != nowClock && nowClock);
+
+        if (portMode==PortMode.serial) {
+            serialHandlerSout(rising);    // Toggles the sout pin
+            serialHandlerSin(rising);     // Collects bits from the sin pin
+        } else {
+                parallelHandlerD(rising);     // Checks stb and reads D-pin
+                parallelHandlerQ(rising);     // Checks buf-queue and writes to Q-pin
+        }
+
+        lastClock=nowClock;
+    }
+
+    @Override
+    public void writeOutputs() throws NodeException {
+        if (portMode==PortMode.serial) {
+            sout.setValue(soutVal);     // Serial
+        } else {
+            pout.set(poutVal, 0);       // Parallel
+            avail.setValue(availVal);
+            bsy.setValue(bsyVal);
+        }
+    }
+
+    @Override
+    public void init(Model model) throws NodeException {
+        buf.clear();    // Clear the buffer when the simulation is started
+    }
+
+    /**
+     *
+     * Receives bytes from the socket and send as a serial bit stream
+     * at the sout pin
+     *
+     * If there's pending data in the buffer and the last transmission
+     * is done then get data and begin.
+     *
+     * Original bits   ---- ---- ---- ---- ---- ---- 7654 3210
+     * Translated bits ---- ---- ---- ---- ---- -SS7 6543 210s
+     * s=startbit (low)  S=stopbit (high)
+     *
+     * The data is sent as 8N2
+     */
+    private void serialHandlerSout(boolean rising) {
+        if (!rising) return;
+        if (!buf.isEmpty() && txData==0) {
+            // Get data and tack on the start and stop bits to it
+            txData=(buf.remove()<<1) | 0x00000600;
+            txTicks=OVERSAMPLECNT;
+        }
+
+        // If the data is not fully sent
+        // then peel off a bit and output it to the sout pin
+        if (txData!=0) {
+            if (--txTicks <= 0) {
+                txTicks=OVERSAMPLECNT;
+                soutVal=txData&1;
+                txData>>=1;
+            }
+        }
+    }
+
+
+    /*
+     * Collects serial stream bits from sin pin and sends bytes to the socket
+     */
+    private void serialHandlerSin(boolean rising) {
+        boolean nowSin=sin.getBool();
+
+        if (!rising) return;
+
+        // If waiting for the startbit wait until line goes low, then initialize
+        // all involved variables
+        if (waitForStartbit) {
+            if (!nowSin) {
+                waitForStartbit = false;
+                rxData = 0;
+                rxBitCnt = BITS_TO_COLLECT;
+                // Test startbit again in the middle of the bit period
+                rxTicks=OVERSAMPLECNT/2;
+            }
+            return;
+        }
+
+        if (--rxTicks == 0) {
+            // Are we at the middle of the start bit? If so then
+            // re-sample it to check if the previous edge was just
+            // a glitch
+            if (rxBitCnt==BITS_TO_COLLECT && nowSin) {
+                waitForStartbit = true;
+                return;
+            }
+            rxTicks=OVERSAMPLECNT;
+
+            // Shift in the data
+            rxData >>= 1;
+            if (nowSin) rxData+=(int) Math.pow(2, BITS_TO_COLLECT-1);
+
+            if (--rxBitCnt == 0) {
+                waitForStartbit = true;
+                // Mask off the start/stopbits and send to socket
+                toSocket((rxData>>1)&0xFF);
+            }
+        }
+    }
+
+    /*
+     * If rising edge on stb then send the parallel-in (pin) to
+     * the socket, and set the bsy flag (it will be automatically
+     * be cleared in X clock cycles to simulate a slow external device)
+     */
+    private void parallelHandlerD(boolean rising) {
+        boolean nowStb = stb.getBool();
+
+        if (lastStb != nowStb) {
+            if (nowStb) {
+                if (!bsy.getBool()) {
+                    toSocket((int) pin.getValue());
+                    bsyVal=1;
+                    bsyTicks=100;
+                }
+            }
+            lastStb=nowStb;
+        }
+
+        // Check if it's time to clear the bsy flag, the countdown
+        // is only done at risging edges of the clock
+        if (rising && bsyTicks>0) {
+            if (--bsyTicks==0) bsyVal=0;
+        }
+    }
+
+    /*
+     * If there's pending data in the buffer and the last data
+     * has been ack'ed then update the Q port and set the avail flag.
+     *
+     * Also check for rising edge on ack and then clear the avail flag
+     */
+    private void parallelHandlerQ(boolean rising) {
+        boolean nowAck = ack.getBool();
+
+        if (!buf.isEmpty() && !avail.getBool() && rising) {
+            poutVal=buf.remove();
+            availVal=1;
+        }
+
+        if (lastAck != nowAck) {
+            if (nowAck) availVal=0;
+            lastAck=nowAck;
+        }
+    }
+
+    /**
+     * The PortSocket thread calls here when new data has
+     * arrived from the network socket.
+     *
+     * @param v - data received from socket
+     */
+    public void fromSocket(int v) {
+        buf.add(v);
+    }
+
+    /**
+     * Send a byte to the network socket
+     *
+     * @param v - data to send to socket
+     */
+    public void toSocket(int v) {
+        DataOutputStream os=portSocket.getOutstream();
+        try {
+            os.writeByte(v);
+        } catch(Exception e) {
+        }
+    }
+
+}

--- a/src/main/java/de/neemann/digital/core/io/PortMode.java
+++ b/src/main/java/de/neemann/digital/core/io/PortMode.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2019 Helmut Neemann & Mats Engstrom.
+ * Use of this source code is governed by the GPL v3 license
+ * that can be found in the LICENSE file.
+ */
+package de.neemann.digital.core.io;
+
+/**
+ * the Port mode
+ */
+public enum PortMode {
+    /**
+     * Serial 8N1
+     */
+    serial,
+    /**
+     * Parallel with stb/rdy
+     */
+    parallel;
+}

--- a/src/main/java/de/neemann/digital/core/io/PortSocket.java
+++ b/src/main/java/de/neemann/digital/core/io/PortSocket.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2019 Helmut Neemann & Mats Engstrom.
+ * Use of this source code is governed by the GPL v3 license
+ * that can be found in the LICENSE file.
+ */
+package de.neemann.digital.core.io;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+
+/**
+ *
+ */
+public class PortSocket extends Thread {
+    private Port port;
+    private boolean telnetMode;
+    private ServerSocket serverSocket;
+    private DataOutputStream outStream;
+
+    /**
+     * @param port instance of creator
+     * @param listenPort - TCP port to listen to
+     * @param telnetMode - True if a telnet terminal will connect
+     */
+    public PortSocket(Port port, int listenPort, boolean telnetMode) {
+        this.port = port;
+        this.telnetMode = telnetMode;
+        this.setDaemon(true);
+        try {
+            serverSocket = new ServerSocket(listenPort);
+        } catch (IOException e) {
+            System.out.println("Error opening port " + listenPort + " : " + e.toString());
+        }
+    }
+
+    /**
+     *
+     */
+    @Override
+    public void run() {
+        Socket lastClient = null;
+        while (true) {
+            try {
+                Socket client = serverSocket.accept();
+                if (lastClient != null) {
+                    lastClient.close();
+                }
+                lastClient = client;
+
+                ClientThread ct = new ClientThread(client);
+                ct.start();
+            } catch (Exception e) {
+                System.out.println("Server exception: " + e.toString());
+            }
+        }
+    }
+
+    /**
+     *
+     */
+    class ClientThread extends Thread {
+        private Socket cli;
+
+        /**
+         *
+         */
+        ClientThread(Socket client) {
+            cli = client;
+        }
+
+        private static final int ECHO = 1;
+        private static final int SGA  = 3;
+        private static final int WILL = 251;
+        private static final int WONT = 252;
+        private static final int DO   = 253;
+        private static final int DONT = 254;
+        private static final int IAC  = 255;
+
+        /**
+         *
+         */
+        public void run() {
+            byte[] buffer = new byte[1024];
+            int read;
+            try {
+                DataInputStream inStream = new DataInputStream(cli.getInputStream());
+                outStream = new DataOutputStream(cli.getOutputStream());
+
+                // If user wants to connect with telnet then we need to
+                // turn off local each and line buffering in the telnet
+                // terminal
+                if (telnetMode) {
+                    outStream.writeByte(IAC);
+                    outStream.writeByte(WILL);
+                    outStream.writeByte(SGA);
+                    outStream.writeByte(IAC);
+                    outStream.writeByte(WILL);
+                    outStream.writeByte(ECHO);
+                    outStream.flush();
+                    Thread.sleep(100); // Wait for a bit and eat up all replies from telnet
+                    inStream.read(buffer);
+                    outStream.writeChars("\r\n[Digital]\r\n");
+                }
+
+                while (true) {
+                    while ((read = inStream.read(buffer)) != -1) {
+                        int lastChar = 0;
+                        for (int i = 0; i < read; i++) {
+                            int c = buffer[i];
+                            if (telnetMode && lastChar == 13 && c == 0) {
+                                c=0; // Ignore character (keep linter happy)
+                            } else {
+                                port.fromSocket(c);
+                            }
+                            lastChar = c;
+                        }
+                    }
+                    inStream.close();
+                    outStream.close();
+                    break;
+                }
+            } catch (Exception ex) {
+                System.out.println(ex);
+            }
+        }
+    }
+
+    /**
+     * @return the current socket output stream
+     */
+    public DataOutputStream getOutstream() {
+        return outStream;
+    }
+
+}

--- a/src/main/java/de/neemann/digital/draw/library/ElementLibrary.java
+++ b/src/main/java/de/neemann/digital/draw/library/ElementLibrary.java
@@ -151,6 +151,7 @@ public class ElementLibrary implements Iterable<ElementLibrary.ElementContainer>
                                 .add(Keyboard.DESCRIPTION)
                                 .add(Terminal.DESCRIPTION)
                                 .add(VGA.DESCRIPTION)
+                                .add(Port.DESCRIPTION)
                                 .add(MIDI.DESCRIPTION)
                         )
                 )

--- a/src/main/java/de/neemann/digital/draw/shapes/ShapeFactory.java
+++ b/src/main/java/de/neemann/digital/draw/shapes/ShapeFactory.java
@@ -123,6 +123,14 @@ public final class ShapeFactory {
         map.put(StepperMotorUnipolar.DESCRIPTION.getName(), StepperMotorShape::new);
         map.put(StepperMotorBipolar.DESCRIPTION.getName(), StepperMotorShape::new);
         map.put(DipSwitch.DESCRIPTION.getName(), DipSwitchShape::new);
+        map.put(Port.DESCRIPTION.getName(),
+        (attributes, inputs, outputs) -> new GenericShape(
+                Port.DESCRIPTION.getShortName(),
+                inputs,
+                outputs,
+                attributes.getLabel(),
+                true,
+                4));
 
         map.put(Switch.DESCRIPTION.getName(), SwitchShape::new);
         map.put(SwitchDT.DESCRIPTION.getName(), SwitchDTShape::new);

--- a/src/main/resources/lang/lang_en.xml
+++ b/src/main/resources/lang/lang_en.xml
@@ -196,7 +196,6 @@
     </string>
     <string name="elem_Probe_pin_in">The measurement value.</string>
 
-
     <!-- IO - more -->
 
     <string name="elem_LightBulb">Light Bulb</string>
@@ -304,7 +303,24 @@
     <string name="elem_MIDI_pin_PC">If high, the value at N is used to change the program (instrument).</string>
     <string name="elem_MIDI_pin_C">Clock</string>
 
-    <string name="elem_StepperMotorUnipolar">Stepper Motor, unipolar</string>
+    <string name="elem_Port">PORT</string>
+    <string name="elem_Port_tt">Serial/Parellel port connected to a TCP socket at port 2323 for communication with external devices/processes.</string>
+    <string name="elem_Port_pin_out">OUT</string>
+    <string name="elem_Port_pin_Q">[Parallel mode] The 8 bits of data received from the socket</string>
+    <string name="elem_Port_pin_avail">[Parallel mode] High if new data has arrived from the socket</string>
+    <string name="elem_Port_pin_bsy">[Parallel mode] Low if the device is ready to receive new data.</string>
+    <string name="elem_Port_pin_C">[Serial mode] This pin expects the bitrate times 16. [Parallel mode] this pin is used for counting 100 clock cycles before clearing the bsy pin.</string>
+    <string name="elem_Port_pin_ack">[Parallel mode] A rising edge acknowledges that the data on Q has been read so new data can be received from the socket. Clears the avail pin.</string>
+    <string name="elem_Port_pin_stb">[Parallel mode] A rising edge latches the data presented at D and transmits it over the socket. The bsy pin is set high and is automatically cleared after 100 clock cycles has passed.</string>
+    <string name="elem_Port_pin_D">[Parallel mode] The 8 bits of data to be sent to the socket.</string>
+    <string name="key_portMode">Mode</string>
+    <string name="key_portMode_tt">Mode of internal interface</string>
+    <string name="key_portMode_serial">Serial 8N1</string>
+    <string name="key_portMode_parallel">Parallel</string>
+    <string name="key_portTelnet">Telnet mode</string>
+    <string name="key_portTelnet_tt">Unchecked for raw/uncooked data on socket, Checked for enabing Telnet mode where commands for turning off echo and buffering automatically is sent.</string>
+
+   <string name="elem_StepperMotorUnipolar">Stepper Motor, unipolar</string>
     <string name="elem_StepperMotorUnipolar_tt">Unipolar stepper motor with two limit position switches.
         Full step drive, half step drive and wave drive are supported.
     </string>


### PR DESCRIPTION
Mostly for enjoyment in my own project I did a TCP socket peripheral to complement the already existing Keyboard/Terminal components in Digital. I also wanted a component that could take serial bitstream as from a simulated UART and use that instead of the parallel-only Keyboard/Terminal.

This peripheral sets up a background TCP socket listener on localhost 2323 (so a connected telnet software can stay connected even if the simulation is started/stopped multiple times). 

It can be set to be used with either Telnet or a raw socket. In telnet mode it sends the appropriate commands to turn off line-buffering and local echo so telnet behaves a bit more like a real terminal. In raw socket mode no such initializations are done.

It can be run in two modes - either Serial or Parallel.  

In serial mode it expects a x16 baud rate clock (like most real UART hardware does) on the CLK pin and then there's a Serial-In pin and a Serial-Out pin.  Both are having their idle-state as high.  Data received serially on the in-pin is sent to the TCP socket and can be read by the telnet client (or any other external software).  Data that is sent to the TCP socket is outputted as a serial bitstream on the output pin.

In parallel mode data presented at the 8-bit input is sent to the socket at a rising edge on the STB pin. The BSY output pin is set high for 100 clock cycles to simulate for a slow(ish) communication.  When data is received from the socket it is presented at the 8-bit output pin and the AVAIL pin is set high to indicate new data. The users circuit is expected to clear the AVAIL with a rising edge on the ACK-pin.

There are examples of the operation in both Serial and Parallel modes in the dig/misc sample folder included in Digital.

 