### PR TITLE
removing  "/linux/" from PATH in lines 14 and 20

### DIFF
--- a/distribution/linux/install.sh
+++ b/distribution/linux/install.sh
@@ -11,13 +11,13 @@ cd "${SCRIPT_PATH}"
 TMP_DIR=`mktemp --directory`
 
 sed -e "s,<EXEC_LOCATION>,${SCRIPT_PATH}/Digital.sh,g" \
-    -e "s,<ICON_LOCATION>,${SCRIPT_PATH}/icon.svg,g" "${SCRIPT_PATH}/linux/desktop.template" > "${TMP_DIR}/${RESOURCE_NAME}.desktop"
+    -e "s,<ICON_LOCATION>,${SCRIPT_PATH}/icon.svg,g" "${SCRIPT_PATH}/desktop.template" > "${TMP_DIR}/${RESOURCE_NAME}.desktop"
     
 mkdir -p "${HOME}/.local/share/applications"
 cp "${TMP_DIR}/${RESOURCE_NAME}.desktop" "${HOME}/.local/share/applications/"
 
 mkdir -p "${HOME}/.local/share/mime/packages"
-cp "${SCRIPT_PATH}/linux/${RESOURCE_NAME}.xml" "${HOME}/.local/share/mime/packages"
+cp "${SCRIPT_PATH}/${RESOURCE_NAME}.xml" "${HOME}/.local/share/mime/packages"
 
 rm "${TMP_DIR}/${RESOURCE_NAME}.desktop"
 rmdir "${TMP_DIR}"


### PR DESCRIPTION
I had the following errors after trying to run the script, so I just edited the path.

```sh
[asari@asari linux]$ sh install.sh 
sed: não foi possível ler /home/asari/Downloads/other-tools/science/digital-logic/Digital/distribution/linux/linux/desktop.template: Arquivo ou diretório inexistente 
cp: não foi possível obter estado de '/home/asari/Downloads/other-tools/science/digital-logic/Digital/distribution/linux/linux/digital-simulator.xml': Arquivo ou diretório inexistente 
Could not parse file "/home/asari/.local/share/applications/digital-simulator.desktop": Key file does not have group ?Desktop Entry? 

```