### PR TITLE
Add widescreen VGA modes

### DIFF
--- a/src/main/java/de/neemann/digital/gui/components/graphics/VGA.java
+++ b/src/main/java/de/neemann/digital/gui/components/graphics/VGA.java
@@ -39,6 +39,7 @@ public class VGA extends Node implements Element {
         vm(new VideoMode(85, 36, 640, 56, 56, 80, 480, 1, 3, 25, true, true));
         vm(new VideoMode(100, 43.16, 640, 40, 64, 104, 480, 1, 3, 25, true, false));
         vm(new VideoMode(85, 35.5, 720, 36, 72, 108, 400, 1, 3, 42, true, false));
+        vm(new VideoMode(60, 27, 720, 16, 62, 60, 480, 9, 6, 30, true, true));
         vm(new VideoMode(60, 34.96, 768, 24, 80, 104, 576, 1, 3, 17, true, false));
         vm(new VideoMode(72, 42.93, 768, 32, 80, 112, 576, 1, 3, 21, true, false));
         vm(new VideoMode(75, 45.51, 768, 40, 80, 120, 576, 1, 3, 22, true, false));
@@ -60,6 +61,7 @@ public class VGA extends Node implements Element {
         vm(new VideoMode(85, 119.65, 1152, 72, 128, 200, 864, 1, 3, 39, true, false));
         vm(new VideoMode(100, 143.47, 1152, 80, 128, 208, 864, 1, 3, 47, true, false));
         vm(new VideoMode(60, 81.62, 1152, 64, 120, 184, 864, 1, 3, 27, true, false));
+        vm(new VideoMode(60, 72.25, 1280, 110, 40, 220, 720, 5, 5, 20, false, false));
         vm(new VideoMode(60, 108, 1280, 48, 112, 248, 1024, 1, 3, 38, false, false));
         vm(new VideoMode(75, 135, 1280, 16, 144, 248, 1024, 1, 3, 38, false, false));
         vm(new VideoMode(85, 157.5, 1280, 64, 160, 224, 1024, 1, 3, 44, false, false));
@@ -84,6 +86,7 @@ public class VGA extends Node implements Element {
         vm(new VideoMode(75, 261, 1792, 96, 216, 352, 1344, 1, 3, 69, true, false));
         vm(new VideoMode(60, 218.3, 1856, 96, 224, 352, 1392, 1, 3, 43, true, false));
         vm(new VideoMode(75, 288, 1856, 128, 224, 352, 1392, 1, 3, 104, true, false));
+        vm(new VideoMode(60, 148.5, 1920, 88, 44, 148, 1080, 4, 4, 37, true, true));
         vm(new VideoMode(60, 193.16, 1920, 128, 208, 336, 1200, 1, 3, 38, true, false));
         vm(new VideoMode(60, 234, 1920, 128, 208, 344, 1440, 1, 3, 56, true, false));
         vm(new VideoMode(75, 297, 1920, 144, 224, 352, 1440, 1, 3, 56, true, false));


### PR DESCRIPTION
Added 720x480, 1280x720 and 1920x1080

This is from this [modeline database](https://www.mythtv.org/wiki/Modeline_Database)

There was several frequencies to choose from, I chose ones that would be easier to do with a PLL on an FPGA. 

720x480 is a common NTSC DVD resolution and many HDTVs support it (and cheap HDMI capture devices). It also has a fairly low 27 MHz required dot clock, and happens to work exactly on my PLL config which is nice.

While I was at it, I added 720p and 1080p widescreen formats, also commonly supported by HDTVs.

I am including this so it's hopefully easier to double check my math (and for documentation for other travelers):
```
ModeLine "720x480" 27.00 720 736 798 858 480 489 495 525 -HSync -VSync 
dot clock: 27.00 MHz, refresh: 60 Hz
H Res: 720, FP: 16, HS: 62, BP: 60
V Res: 480, FP: 9,  VS: 6,   BP: 30
Negative on both sync signals

ModeLine "1280x720" 74.25 1280 1390 1430 1650 720 725 730 750 +HSync +VSync 
dot clock: 74.25 MHz, refresh: 60 Hz
H Res: 1280, FP: 110, HS: 40, BP: 220 
V Res: 720,  FP: 5,   VS: 5,  BP: 20
positive on both sync signals

ModeLine "1920x1080" 148.50 1920 2008 2052 2200 1080 1084 1088 1125 -HSync -VSync 
dot clock: 148.50 MHz
H Res: 1920, FP: 88, HS: 44, BP: 148
V Res: 1080, FP: 4,  VS: 4,  BP: 37
negative on both sync signals
```
