### PR TITLE
Add missing quotes in start shell script, fixes hneemann/Digital#748

### DIFF
--- a/distribution/linux/Digital.sh
+++ b/distribution/linux/Digital.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 DIR="$( cd "$( dirname "$( realpath "${BASH_SOURCE[0]}" )" )" >/dev/null && pwd )"
-java -jar $DIR/Digital.jar "$1"
+java -jar "$DIR"/Digital.jar "$1"


### PR DESCRIPTION
Adds quotation marks around the DIR variable, which allows placing Digital in a directory containing spaces