### PR TITLE
Add option to skip HDL export for circuits

### DIFF
--- a/src/main/java/de/neemann/digital/core/element/Keys.java
+++ b/src/main/java/de/neemann/digital/core/element/Keys.java
@@ -959,4 +959,9 @@ public final class Keys {
     public static final Key<Boolean> TELNET_ESCAPE =
             new Key<>("telnetEscape", true).allowGroupEdit();
 
+    /**
+     * Skips HDL output for this circuit
+     */
+    public static final Key<Boolean> SKIP_HDL =
+            new Key<>("skipHDL", false).setSecondary();
 }

--- a/src/main/java/de/neemann/digital/gui/components/CircuitComponent.java
+++ b/src/main/java/de/neemann/digital/gui/components/CircuitComponent.java
@@ -86,6 +86,7 @@ public class CircuitComponent extends JComponent implements ChangedListener, Lib
         ATTR_LIST.add(Keys.PRELOAD_PROGRAM);
         ATTR_LIST.add(Keys.PROGRAM_TO_PRELOAD);
         ATTR_LIST.add(Keys.IS_GENERIC);
+        ATTR_LIST.add(Keys.SKIP_HDL);
     }
 
     /**

--- a/src/main/java/de/neemann/digital/hdl/model2/HDLCircuit.java
+++ b/src/main/java/de/neemann/digital/hdl/model2/HDLCircuit.java
@@ -50,6 +50,7 @@ public class HDLCircuit implements Iterable<HDLNode>, HDLModel.BitProvider, Prin
     private final String description;
     private final File origin;
     private final ArrayList<HDLNode> nodes;
+    private final boolean skipHDL;
     private ArrayList<HDLPort> ports;
     private NetList netList;
     private HashMap<Net, HDLNet> nets;
@@ -100,6 +101,8 @@ public class HDLCircuit implements Iterable<HDLNode>, HDLModel.BitProvider, Prin
         netList = new NetList(circuit);
         description = Lang.evalMultilingualContent(circuit.getAttributes().get(Keys.DESCRIPTION));
         this.origin = circuit.getOrigin();
+
+        this.skipHDL = circuit.getAttributes().get(Keys.SKIP_HDL);
 
         ArrayList<ClockInfo> clocks = new ArrayList<>();
 
@@ -474,6 +477,13 @@ public class HDLCircuit implements Iterable<HDLNode>, HDLModel.BitProvider, Prin
      */
     public boolean hasDescription() {
         return description != null && description.trim().length() > 0;
+    }
+
+    /**
+     * @return true if HDL export should be skipped for this circuit
+     */
+    public boolean shouldSkipHDLExport() {
+        return this.skipHDL;
     }
 
     /**

--- a/src/main/java/de/neemann/digital/hdl/verilog2/VerilogCreator.java
+++ b/src/main/java/de/neemann/digital/hdl/verilog2/VerilogCreator.java
@@ -124,6 +124,11 @@ public class VerilogCreator {
      * @throws HGSEvalException HGSEvalException
      */
     public void printHDLCircuit(HDLCircuit circuit, String moduleName, File root) throws IOException, HDLException, HGSEvalException {
+        // skip the HDL export and any dependant circuits
+        if (circuit.shouldSkipHDLExport()) {
+            return;
+        }
+
         // at first print all used entities to maintain the correct order
         for (HDLNode node : circuit)
             if (node instanceof HDLNodeCustom)

--- a/src/main/java/de/neemann/digital/hdl/vhdl2/VHDLCreator.java
+++ b/src/main/java/de/neemann/digital/hdl/vhdl2/VHDLCreator.java
@@ -111,6 +111,11 @@ public class VHDLCreator {
      * @throws HGSEvalException HGSEvalException
      */
     public void printHDLCircuit(HDLCircuit circuit, File root) throws IOException, HDLException, HGSEvalException {
+        // skip the HDL export and any dependant circuits
+        if (circuit.shouldSkipHDLExport()) {
+            return;
+        }
+
         // at first print all used entities to maintain the correct order
         for (HDLNode node : circuit)
             if (node instanceof HDLNodeCustom)

--- a/src/main/resources/lang/lang_de.xml
+++ b/src/main/resources/lang/lang_de.xml
@@ -1686,6 +1686,12 @@ Sind evtl. die Namen der Variablen nicht eindeutig?</string>
     <string name="key_port">Port</string>
     <string name="key_port_tt">Der vom Server zu öffnende Port.</string>
 
+    <!-- TODO: Just run through google translate, needs proper translation: -->
+    <string name="key_skipHDL">Verilog/VHDL-Export überspringen</string>
+    <string name="key_skipHDL_tt">Überspringt die Generierung der Interna der Schaltung beim
+        Verilog/VHDL-Export. Die Verweise auf die Schaltung werden beibehalten, sodass die
+        Implementierung überschrieben werden kann.</string>
+
     <string name="key_colorScheme">Farbschema</string>
     <string name="key_colorScheme_DEFAULT">Normal</string>
     <string name="key_colorScheme_DARK">Dunkel</string>

--- a/src/main/resources/lang/lang_en.xml
+++ b/src/main/resources/lang/lang_en.xml
@@ -1668,6 +1668,11 @@
     <string name="key_port">Port</string>
     <string name="key_port_tt">The port to be opened by the server.</string>
 
+    <string name="key_skipHDL">Skip in Verilog/VHDL export</string>
+    <string name="key_skipHDL_tt">Skips generating the internals of the circuit in Verilog/VHDL
+        export. The references to the circuit are kept, making it possible to override the
+        implementation.</string>
+
     <string name="key_colorScheme">Color scheme</string>
     <string name="key_colorScheme_DEFAULT">Normal</string>
     <string name="key_colorScheme_DARK">Dark</string>


### PR DESCRIPTION
Closes #796 

Implements an option to skip HDL export for a circuit in the advanced circuit specific settings.

This will skip emitting the module definition for the circuit and all dependencies only required by this circuit.

Any references to the module are left intact, allowing a separate verilog or VHDL implementation to be provided.

## TODO:

- [ ] German translation of the Key
- [ ] Tests need to be written (though it's pretty simple, maybe that can be skipped?)
- [ ] Help documentation could maybe be updated to mention the feature?
- [ ] Maybe checks inside the circuit can also be skipped? That way "invalid" circuits won't block HDL generation when they contain un-exportable components / errors.
