### PR TITLE
Fix flaky tests in DataFieldConverterTest.java

### DIFF
--- a/src/test/java/de/neemann/digital/core/memory/DataFieldConverterTest.java
+++ b/src/test/java/de/neemann/digital/core/memory/DataFieldConverterTest.java
@@ -64,10 +64,10 @@ public class DataFieldConverterTest extends TestCase {
 
         XStream xs = getxStream();
         String xml = xs.toXML(new Test(d1, d2));
-        assertEquals("<?xml version=\"1.0\" ?><test>" +
-                "<d1>1,4*0,2</d1>" +
-                "<d2>3,7*0,4</d2>" +
-                "</test>", xml);
+        
+        String case1 = "<?xml version=\"1.0\" ?><test>" + "<d1>1,4*0,2</d1>" + "<d2>3,7*0,4</d2>" + "</test>";
+        String case2 = "<?xml version=\"1.0\" ?><test>" + "<d2>3,7*0,4</d2>" + "<d1>1,4*0,2</d1>" + "</test>";
+        assertTrue(Arrays.asList(case1, case2).contains(xml));
     }
 
     public void testMarshalObj2() {
@@ -79,10 +79,10 @@ public class DataFieldConverterTest extends TestCase {
 
         XStream xs = getxStream();
         String xml = xs.toXML(new Test(d1, d2));
-        assertEquals("<?xml version=\"1.0\" ?><test>" +
-                "<d1>5*0,2</d1>" +
-                "<d2>8*0,4</d2>" +
-                "</test>", xml);
+
+        String case1 = "<?xml version=\"1.0\" ?><test>" + "<d1>5*0,2</d1>" + "<d2>8*0,4</d2>" + "</test>";
+        String case2 = "<?xml version=\"1.0\" ?><test>" + "<d2>8*0,4</d2>" + "<d1>5*0,2</d1>" + "</test>";
+        assertTrue(Arrays.asList(case1, case2).contains(xml));
     }
 
     public void testMarshalObj3() {
@@ -97,10 +97,10 @@ public class DataFieldConverterTest extends TestCase {
 
         XStream xs = getxStream();
         String xml = xs.toXML(new Test(d1, d2));
-        assertEquals("<?xml version=\"1.0\" ?><test>" +
-                "<d1>11*2</d1>" +
-                "<d2>11*1,11*2,11*3,11*4,11*5,11*6,11*7,11*8,11*9,11*a,11*b</d2>" +
-                "</test>", xml);
+
+        String case1 = "<?xml version=\"1.0\" ?><test>" + "<d1>11*2</d1>" + "<d2>11*1,11*2,11*3,11*4,11*5,11*6,11*7,11*8,11*9,11*a,11*b</d2>" + "</test>";
+        String case2 = "<?xml version=\"1.0\" ?><test>" + "<d2>11*1,11*2,11*3,11*4,11*5,11*6,11*7,11*8,11*9,11*a,11*b</d2>" + "<d1>11*2</d1>" + "</test>";
+        assertTrue(Arrays.asList(case1, case2).contains(xml));
     }
 
     public void testUnmarshalObj() {

--- a/src/test/java/de/neemann/digital/core/memory/DataFieldConverterTest.java
+++ b/src/test/java/de/neemann/digital/core/memory/DataFieldConverterTest.java
@@ -8,6 +8,7 @@ package de.neemann.digital.core.memory;
 import com.thoughtworks.xstream.XStream;
 import de.neemann.digital.XStreamValid;
 import junit.framework.TestCase;
+
 /**
  *
  */
@@ -52,10 +53,12 @@ public class DataFieldConverterTest extends TestCase {
         }
     }
 
-    void checkEquals(String prefix, String d1, String d2, String suffix, String xml) {
-         String case1 = prefix + d1 + d2 + suffix;
-         String case2 = prefix + d2 + d1 + suffix;
-         assertTrue(case1.equals(xml) || case2.equals(xml));
+    void checkEquals(String d1, String d2, String xml) {
+        String prefix = "<?xml version=\"1.0\" ?><test>";
+        String suffix = "</test>";
+        String case1 = prefix + d1 + d2 + suffix;
+        String case2 = prefix + d2 + d1 + suffix;
+        assertTrue(case1.equals(xml) || case2.equals(xml));
     }
 
     public void testMarshalObj() {
@@ -70,12 +73,10 @@ public class DataFieldConverterTest extends TestCase {
         XStream xs = getxStream();
         String xml = xs.toXML(new Test(d1, d2));
         
-        String prefix = "<?xml version=\"1.0\" ?><test>";
+        
         String d1_str = "<d1>1,4*0,2</d1>";
         String d2_str = "<d2>3,7*0,4</d2>";
-        String suffix = "</test>";
-
-        checkEquals(prefix, d1_str, d2_str, suffix, xml);
+        checkEquals(d1_str, d2_str, xml);
     }
 
     public void testMarshalObj2() {
@@ -88,12 +89,9 @@ public class DataFieldConverterTest extends TestCase {
         XStream xs = getxStream();
         String xml = xs.toXML(new Test(d1, d2));
 
-        String prefix = "<?xml version=\"1.0\" ?><test>";
         String d1_str = "<d1>5*0,2</d1>";
         String d2_str = "<d2>8*0,4</d2>";
-        String suffix = "</test>";
-
-        checkEquals(prefix, d1_str, d2_str, suffix, xml);
+        checkEquals(d1_str, d2_str, xml);
     }
 
     public void testMarshalObj3() {
@@ -109,12 +107,9 @@ public class DataFieldConverterTest extends TestCase {
         XStream xs = getxStream();
         String xml = xs.toXML(new Test(d1, d2));
         
-        String prefix = "<?xml version=\"1.0\" ?><test>";
         String d1_str = "<d1>11*2</d1>";
         String d2_str = "<d2>11*1,11*2,11*3,11*4,11*5,11*6,11*7,11*8,11*9,11*a,11*b</d2>";
-        String suffix = "</test>";
-
-        checkEquals(prefix, d1_str, d2_str, suffix, xml);
+        checkEquals(d1_str, d2_str, xml);
     }
 
     public void testUnmarshalObj() {

--- a/src/test/java/de/neemann/digital/core/memory/DataFieldConverterTest.java
+++ b/src/test/java/de/neemann/digital/core/memory/DataFieldConverterTest.java
@@ -8,7 +8,6 @@ package de.neemann.digital.core.memory;
 import com.thoughtworks.xstream.XStream;
 import de.neemann.digital.XStreamValid;
 import junit.framework.TestCase;
-import java.util.*;
 /**
  *
  */
@@ -53,6 +52,12 @@ public class DataFieldConverterTest extends TestCase {
         }
     }
 
+    void checkEquals(String prefix, String d1, String d2, String suffix, String xml) {
+         String case1 = prefix + d1 + d2 + suffix;
+         String case2 = prefix + d2 + d1 + suffix;
+         assertTrue(case1.equals(xml) || case2.equals(xml));
+    }
+
     public void testMarshalObj() {
         final DataField d1 = new DataField(20);
         d1.setData(0, 1);
@@ -65,15 +70,12 @@ public class DataFieldConverterTest extends TestCase {
         XStream xs = getxStream();
         String xml = xs.toXML(new Test(d1, d2));
         
-        String case1 = "<?xml version=\"1.0\" ?><test>" + 
-            "<d1>1,4*0,2</d1>" + 
-            "<d2>3,7*0,4</d2>" + 
-            "</test>";
-        String case2 = "<?xml version=\"1.0\" ?><test>" + 
-            "<d2>3,7*0,4</d2>" + 
-            "<d1>1,4*0,2</d1>" + 
-            "</test>";
-        assertTrue(Arrays.asList(case1, case2).contains(xml));
+        String prefix = "<?xml version=\"1.0\" ?><test>";
+        String d1_str = "<d1>1,4*0,2</d1>";
+        String d2_str = "<d2>3,7*0,4</d2>";
+        String suffix = "</test>";
+
+        checkEquals(prefix, d1_str, d2_str, suffix, xml);
     }
 
     public void testMarshalObj2() {
@@ -86,15 +88,12 @@ public class DataFieldConverterTest extends TestCase {
         XStream xs = getxStream();
         String xml = xs.toXML(new Test(d1, d2));
 
-        String case1 = "<?xml version=\"1.0\" ?><test>" + 
-            "<d1>5*0,2</d1>" + 
-            "<d2>8*0,4</d2>" + 
-            "</test>";
-        String case2 = "<?xml version=\"1.0\" ?><test>" + 
-            "<d2>8*0,4</d2>" + 
-            "<d1>5*0,2</d1>" + 
-            "</test>";
-        assertTrue(Arrays.asList(case1, case2).contains(xml));
+        String prefix = "<?xml version=\"1.0\" ?><test>";
+        String d1_str = "<d1>5*0,2</d1>";
+        String d2_str = "<d2>8*0,4</d2>";
+        String suffix = "</test>";
+
+        checkEquals(prefix, d1_str, d2_str, suffix, xml);
     }
 
     public void testMarshalObj3() {
@@ -109,16 +108,13 @@ public class DataFieldConverterTest extends TestCase {
 
         XStream xs = getxStream();
         String xml = xs.toXML(new Test(d1, d2));
+        
+        String prefix = "<?xml version=\"1.0\" ?><test>";
+        String d1_str = "<d1>11*2</d1>";
+        String d2_str = "<d2>11*1,11*2,11*3,11*4,11*5,11*6,11*7,11*8,11*9,11*a,11*b</d2>";
+        String suffix = "</test>";
 
-        String case1 = "<?xml version=\"1.0\" ?><test>" + 
-            "<d1>11*2</d1>" + 
-            "<d2>11*1,11*2,11*3,11*4,11*5,11*6,11*7,11*8,11*9,11*a,11*b</d2>" + 
-            "</test>";
-        String case2 = "<?xml version=\"1.0\" ?><test>" + 
-            "<d2>11*1,11*2,11*3,11*4,11*5,11*6,11*7,11*8,11*9,11*a,11*b</d2>" + 
-            "<d1>11*2</d1>" + 
-            "</test>";
-        assertTrue(Arrays.asList(case1, case2).contains(xml));
+        checkEquals(prefix, d1_str, d2_str, suffix, xml);
     }
 
     public void testUnmarshalObj() {

--- a/src/test/java/de/neemann/digital/core/memory/DataFieldConverterTest.java
+++ b/src/test/java/de/neemann/digital/core/memory/DataFieldConverterTest.java
@@ -65,8 +65,14 @@ public class DataFieldConverterTest extends TestCase {
         XStream xs = getxStream();
         String xml = xs.toXML(new Test(d1, d2));
         
-        String case1 = "<?xml version=\"1.0\" ?><test>" + "<d1>1,4*0,2</d1>" + "<d2>3,7*0,4</d2>" + "</test>";
-        String case2 = "<?xml version=\"1.0\" ?><test>" + "<d2>3,7*0,4</d2>" + "<d1>1,4*0,2</d1>" + "</test>";
+        String case1 = "<?xml version=\"1.0\" ?><test>" + 
+            "<d1>1,4*0,2</d1>" + 
+            "<d2>3,7*0,4</d2>" + 
+            "</test>";
+        String case2 = "<?xml version=\"1.0\" ?><test>" + 
+            "<d2>3,7*0,4</d2>" + 
+            "<d1>1,4*0,2</d1>" + 
+            "</test>";
         assertTrue(Arrays.asList(case1, case2).contains(xml));
     }
 
@@ -80,8 +86,14 @@ public class DataFieldConverterTest extends TestCase {
         XStream xs = getxStream();
         String xml = xs.toXML(new Test(d1, d2));
 
-        String case1 = "<?xml version=\"1.0\" ?><test>" + "<d1>5*0,2</d1>" + "<d2>8*0,4</d2>" + "</test>";
-        String case2 = "<?xml version=\"1.0\" ?><test>" + "<d2>8*0,4</d2>" + "<d1>5*0,2</d1>" + "</test>";
+        String case1 = "<?xml version=\"1.0\" ?><test>" + 
+            "<d1>5*0,2</d1>" + 
+            "<d2>8*0,4</d2>" + 
+            "</test>";
+        String case2 = "<?xml version=\"1.0\" ?><test>" + 
+            "<d2>8*0,4</d2>" + 
+            "<d1>5*0,2</d1>" + 
+            "</test>";
         assertTrue(Arrays.asList(case1, case2).contains(xml));
     }
 
@@ -98,8 +110,14 @@ public class DataFieldConverterTest extends TestCase {
         XStream xs = getxStream();
         String xml = xs.toXML(new Test(d1, d2));
 
-        String case1 = "<?xml version=\"1.0\" ?><test>" + "<d1>11*2</d1>" + "<d2>11*1,11*2,11*3,11*4,11*5,11*6,11*7,11*8,11*9,11*a,11*b</d2>" + "</test>";
-        String case2 = "<?xml version=\"1.0\" ?><test>" + "<d2>11*1,11*2,11*3,11*4,11*5,11*6,11*7,11*8,11*9,11*a,11*b</d2>" + "<d1>11*2</d1>" + "</test>";
+        String case1 = "<?xml version=\"1.0\" ?><test>" + 
+            "<d1>11*2</d1>" + 
+            "<d2>11*1,11*2,11*3,11*4,11*5,11*6,11*7,11*8,11*9,11*a,11*b</d2>" + 
+            "</test>";
+        String case2 = "<?xml version=\"1.0\" ?><test>" + 
+            "<d2>11*1,11*2,11*3,11*4,11*5,11*6,11*7,11*8,11*9,11*a,11*b</d2>" + 
+            "<d1>11*2</d1>" + 
+            "</test>";
         assertTrue(Arrays.asList(case1, case2).contains(xml));
     }
 

--- a/src/test/java/de/neemann/digital/core/memory/DataFieldConverterTest.java
+++ b/src/test/java/de/neemann/digital/core/memory/DataFieldConverterTest.java
@@ -8,7 +8,7 @@ package de.neemann.digital.core.memory;
 import com.thoughtworks.xstream.XStream;
 import de.neemann.digital.XStreamValid;
 import junit.framework.TestCase;
-
+import java.util.*;
 /**
  *
  */


### PR DESCRIPTION
Hi,

Since there was no response to #866, I'm also opening this PR but can revise it if you want.
Also, this PR is related to #870, but fixed more flaky tests in  `DataFieldConverterTest.java `

By running the following command:
`mvn install -DskipTests`,
`mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=de.neemann.digital.core.memory.DataFieldConverterTest`

Three tests `testMarshalObj`, `testMarshalObj2`, `testMarshalObj3` in `de.neemann.digital.core.memory.DataFieldConverterTest` will fail sometimes.

The reason is that method `xStream.toXML()` in `com.thoughtworks.xstream.XStream` is not deterministic: `Xstreamer.toXML(object)` method first serializes the object using HashMap and then convert the XML object to string in the order of keys in the HashMap. I fixed the flakiness by checking whether the actual output is in the expected list, which contains all the possible XML combination orders.