### PR TITLE
Ignore windowDeactivated Event when inserting element

### DIFF
--- a/src/main/java/de/neemann/digital/gui/components/CircuitComponent.java
+++ b/src/main/java/de/neemann/digital/gui/components/CircuitComponent.java
@@ -280,7 +280,7 @@ public class CircuitComponent extends JComponent implements ChangedListener, Lib
             parent.addWindowListener(new WindowAdapter() {
                 @Override
                 public void windowDeactivated(WindowEvent e) {
-                    if (!(activeMouseController instanceof MouseControllerWizard || activeMouseController == mouseSelect))
+                    if (!(activeMouseController instanceof MouseControllerWizard || activeMouseController == mouseSelect || activeMouseController == mouseInsertElement))
                         activeMouseController.escapePressed();
                 }
             });


### PR DESCRIPTION
I came across this problem when trying to use the BehavioralFixtureCreator (Edit -> Create Bahavior Fixing Test Case) on the Sway window manager on Linux. After creating a fixture and clicking the "Complete" button in the popup dialog, the green "Test" rectangle flashes up (at best) and is then removed immediately. I therefore can't create a test this way.

After debugging the issue a bit, I found out a `windowDeactivated` event is fired immediately after closing the dialog, which seems to cancel the insert mode and therefore prevents me from placing the green "Test" rectangle.

This behavior can be circumvented by adding the additional check `activeMouseController == mouseInsertElement`. As I am completely new to this project however, I'm unaware of other desired behavior this change could possibly affect negatively. I'd be very thankful if someone experienced could look into this and find a solution which works for all platforms / window managers. I can imagine it could be difficult to reproduce this issue on other platforms, as `windowDeactivated` events might be fired differently, so please let me know if I can help any further (e. g. provide logs of the events).