### PR TITLE
Add startsWith function to HGS language

### DIFF
--- a/src/main/java/de/neemann/digital/hdl/hgs/Context.java
+++ b/src/main/java/de/neemann/digital/hdl/hgs/Context.java
@@ -58,6 +58,7 @@ public class Context implements HGSMap {
         BUILT_IN.put("loadHex", new FunctionLoadHex());
         BUILT_IN.put("loadFile", new FunctionLoadFile());
         BUILT_IN.put("sizeOf", new Func(1, args -> Value.toArray(args[0]).hgsArraySize()));
+        BUILT_IN.put("startsWith", new Func(2, args -> args[0].toString().startsWith(args[1].toString())));
     }
 
     private final Context parent;


### PR DESCRIPTION
I'm creating a config for a Butterstick board & needed a way to neatly customize some constraints for all ports starting with some prefix. 

Example of how I use it:

```
func pin(name, pin) {
    io_type := "LVCMOS33";
    misc := "";

    if ( startsWith(name, "user_btn") ) { io_type = "SSTL135_I"; }
    if ( startsWith(name, "ulpi_") ) { io_type = "LVCMOS18"; misc="SLEWRATE=FAST"; }
    if ( name = "rst_n" ) { misc = "OPENDRAIN=ON"; }

    config := "LOCATE COMP \""+ name + "\" SITE \""+ pin +"\";";
    config = config + "\nIOBUF PORT \""+ name + "\" IO_TYPE=" + io_type + " " + misc + ";";

    if (name = "clk30") { config = config + "\nFREQUENCY PORT \"clk30\" 30.0 MHz;"; }

    return config + "\n";
}
for (i:=0; i<sizeOf(model.ports); i++) {
    port:=model.ports[i];
    if (port.bits=1) {
        println(pin(port.name, port.pin));
    } else {
        pins := splitString(port.pin);
        for (p:=0;p<sizeOf(pins);p++) {
          println(pin(port.name + "[" + p + "]", pins[p]));
        }
    }
}
```

It builds & verifies. And I've confirmed it works for generating my constraints file.

Since it seems most trivial functions are not explicitly tested, I didn't add one for this either. Let me know if I should add one though!