### PR TITLE
74xx library addition for 4-way NOR gates

### DIFF
--- a/src/main/dig/lib/DIL Chips/74xx/basic/744002.dig
+++ b/src/main/dig/lib/DIL Chips/74xx/basic/744002.dig
@@ -12,7 +12,7 @@
     </entry>
     <entry>
       <string>Description</string>
-      <string>dual 4-input NOR gate with strobe</string>
+      <string>dual 4-input NOR gate</string>
     </entry>
     <entry>
       <string>lockedMode</string>
@@ -33,10 +33,38 @@
         </entry>
         <entry>
           <string>pinNumber</string>
-          <string>1</string>
+          <string>2</string>
         </entry>
       </elementAttributes>
       <pos x="300" y="220"/>
+    </visualElement>
+    <visualElement>
+      <elementName>In</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>1B</string>
+        </entry>
+        <entry>
+          <string>pinNumber</string>
+          <string>3</string>
+        </entry>
+      </elementAttributes>
+      <pos x="300" y="260"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>1Y</string>
+        </entry>
+        <entry>
+          <string>pinNumber</string>
+          <string>1</string>
+        </entry>
+      </elementAttributes>
+      <pos x="460" y="280"/>
     </visualElement>
     <visualElement>
       <elementName>In</elementName>
@@ -50,91 +78,7 @@
           <string>4</string>
         </entry>
       </elementAttributes>
-      <pos x="300" y="280"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Out</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>1Y</string>
-        </entry>
-        <entry>
-          <string>pinNumber</string>
-          <string>6</string>
-        </entry>
-      </elementAttributes>
-      <pos x="560" y="280"/>
-    </visualElement>
-    <visualElement>
-      <elementName>In</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>2A</string>
-        </entry>
-        <entry>
-          <string>pinNumber</string>
-          <string>9</string>
-        </entry>
-      </elementAttributes>
-      <pos x="300" y="460"/>
-    </visualElement>
-    <visualElement>
-      <elementName>In</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>2C</string>
-        </entry>
-        <entry>
-          <string>pinNumber</string>
-          <string>12</string>
-        </entry>
-      </elementAttributes>
-      <pos x="300" y="520"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Out</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>2Y</string>
-        </entry>
-        <entry>
-          <string>pinNumber</string>
-          <string>8</string>
-        </entry>
-      </elementAttributes>
-      <pos x="560" y="520"/>
-    </visualElement>
-    <visualElement>
-      <elementName>In</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>1B</string>
-        </entry>
-        <entry>
-          <string>pinNumber</string>
-          <string>2</string>
-        </entry>
-      </elementAttributes>
-      <pos x="140" y="240"/>
-    </visualElement>
-    <visualElement>
-      <elementName>In</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>2B</string>
-        </entry>
-        <entry>
-          <string>pinNumber</string>
-          <string>10</string>
-        </entry>
-      </elementAttributes>
-      <pos x="140" y="480"/>
+      <pos x="300" y="300"/>
     </visualElement>
     <visualElement>
       <elementName>In</elementName>
@@ -148,7 +92,49 @@
           <string>5</string>
         </entry>
       </elementAttributes>
-      <pos x="140" y="300"/>
+      <pos x="300" y="340"/>
+    </visualElement>
+    <visualElement>
+      <elementName>In</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>2B</string>
+        </entry>
+        <entry>
+          <string>pinNumber</string>
+          <string>10</string>
+        </entry>
+      </elementAttributes>
+      <pos x="300" y="420"/>
+    </visualElement>
+    <visualElement>
+      <elementName>In</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>2A</string>
+        </entry>
+        <entry>
+          <string>pinNumber</string>
+          <string>9</string>
+        </entry>
+      </elementAttributes>
+      <pos x="300" y="380"/>
+    </visualElement>
+    <visualElement>
+      <elementName>In</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>2C</string>
+        </entry>
+        <entry>
+          <string>pinNumber</string>
+          <string>11</string>
+        </entry>
+      </elementAttributes>
+      <pos x="300" y="460"/>
     </visualElement>
     <visualElement>
       <elementName>In</elementName>
@@ -159,15 +145,49 @@
         </entry>
         <entry>
           <string>pinNumber</string>
+          <string>12</string>
+        </entry>
+      </elementAttributes>
+      <pos x="300" y="500"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>2Y</string>
+        </entry>
+        <entry>
+          <string>pinNumber</string>
           <string>13</string>
         </entry>
       </elementAttributes>
-      <pos x="140" y="540"/>
+      <pos x="460" y="440"/>
+    </visualElement>
+    <visualElement>
+      <elementName>NOr</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Inputs</string>
+          <int>4</int>
+        </entry>
+      </elementAttributes>
+      <pos x="340" y="240"/>
+    </visualElement>
+    <visualElement>
+      <elementName>NOr</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Inputs</string>
+          <int>4</int>
+        </entry>
+      </elementAttributes>
+      <pos x="340" y="400"/>
     </visualElement>
     <visualElement>
       <elementName>PowerSupply</elementName>
       <elementAttributes/>
-      <pos x="340" y="700"/>
+      <pos x="340" y="560"/>
     </visualElement>
     <visualElement>
       <elementName>In</elementName>
@@ -185,7 +205,7 @@
           <value v="1" z="false"/>
         </entry>
       </elementAttributes>
-      <pos x="300" y="700"/>
+      <pos x="300" y="560"/>
     </visualElement>
     <visualElement>
       <elementName>In</elementName>
@@ -199,65 +219,7 @@
           <string>7</string>
         </entry>
       </elementAttributes>
-      <pos x="300" y="740"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Or</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Inputs</string>
-          <int>4</int>
-        </entry>
-      </elementAttributes>
-      <pos x="340" y="220"/>
-    </visualElement>
-    <visualElement>
-      <elementName>In</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>1G</string>
-        </entry>
-        <entry>
-          <string>pinNumber</string>
-          <string>3</string>
-        </entry>
-      </elementAttributes>
-      <pos x="140" y="380"/>
-    </visualElement>
-    <visualElement>
-      <elementName>NAnd</elementName>
-      <elementAttributes/>
-      <pos x="440" y="260"/>
-    </visualElement>
-    <visualElement>
-      <elementName>Or</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Inputs</string>
-          <int>4</int>
-        </entry>
-      </elementAttributes>
-      <pos x="340" y="460"/>
-    </visualElement>
-    <visualElement>
-      <elementName>In</elementName>
-      <elementAttributes>
-        <entry>
-          <string>Label</string>
-          <string>2G</string>
-        </entry>
-        <entry>
-          <string>pinNumber</string>
-          <string>11</string>
-        </entry>
-      </elementAttributes>
-      <pos x="140" y="620"/>
-    </visualElement>
-    <visualElement>
-      <elementName>NAnd</elementName>
-      <elementAttributes/>
-      <pos x="440" y="500"/>
+      <pos x="300" y="600"/>
     </visualElement>
     <visualElement>
       <elementName>Testcase</elementName>
@@ -265,114 +227,112 @@
         <entry>
           <string>Testdata</string>
           <testData>
-            <dataString>1A 1B 1C 1D 1G 1Y 2A 2B 2C 2D 2G 2Y
-1  X  X  X  1  0  X  X  X  X  X  X
-X  X  X  X  X  X  1  X  X  X  1  0
-X  1  X  X  1  0  X  X  X  X  X  X
-X  X  X  X  X  X  X  1  X  X  1  0
-X  X  1  X  1  0  X  X  X  X  X  X
-X  X  X  X  X  X  X  X  1  X  1  0
-X  X  X  1  1  0  X  X  X  X  X  X
-X  X  X  X  X  X  X  X  X  1  1  0
-0  0  0  0  X  1  X  X  X  X  X  X
-X  X  X  X  X  X  0  0  0  0  X  1
-X  X  X  X  0  1  X  X  X  X  X  X
-X  X  X  X  X  X  X  X  X  X  0  1
+            <dataString>1A 1B 1C 1D 1Y 2A 2B 2C 2D 2Y
+0  0  0  0  1  X  X  X  X  X
+X  X  X  X  X  0  0  0  0  1
+1  X  X  X  0  X  X  X  X  X
+X  X  X  X  X  1  X  X  X  0
+X  1  X  X  0  X  X  X  X  X
+X  X  X  X  X  X  1  X  X  0
+X  X  1  X  0  X  X  X  X  X
+X  X  X  X  X  X  X  1  X  0
+X  X  X  1  0  X  X  X  X  X
+X  X  X  X  X  X  X  X  1  0
 </dataString>
           </testData>
         </entry>
       </elementAttributes>
-      <pos x="500" y="620"/>
+      <pos x="500" y="540"/>
     </visualElement>
   </visualElements>
   <wires>
     <wire>
-      <p1 x="140" y="480"/>
+      <p1 x="320" y="320"/>
+      <p2 x="340" y="320"/>
+    </wire>
+    <wire>
+      <p1 x="320" y="480"/>
       <p2 x="340" y="480"/>
     </wire>
     <wire>
-      <p1 x="400" y="260"/>
-      <p2 x="440" y="260"/>
+      <p1 x="300" y="260"/>
+      <p2 x="340" y="260"/>
     </wire>
     <wire>
-      <p1 x="300" y="740"/>
-      <p2 x="320" y="740"/>
+      <p1 x="320" y="580"/>
+      <p2 x="340" y="580"/>
     </wire>
     <wire>
-      <p1 x="520" y="520"/>
-      <p2 x="560" y="520"/>
+      <p1 x="300" y="420"/>
+      <p2 x="340" y="420"/>
     </wire>
     <wire>
-      <p1 x="300" y="520"/>
-      <p2 x="340" y="520"/>
-    </wire>
-    <wire>
-      <p1 x="140" y="300"/>
+      <p1 x="300" y="300"/>
       <p2 x="340" y="300"/>
-    </wire>
-    <wire>
-      <p1 x="420" y="300"/>
-      <p2 x="440" y="300"/>
     </wire>
     <wire>
       <p1 x="300" y="460"/>
       <p2 x="340" y="460"/>
     </wire>
     <wire>
-      <p1 x="140" y="620"/>
-      <p2 x="420" y="620"/>
+      <p1 x="300" y="560"/>
+      <p2 x="340" y="560"/>
     </wire>
     <wire>
-      <p1 x="140" y="240"/>
+      <p1 x="320" y="240"/>
       <p2 x="340" y="240"/>
     </wire>
     <wire>
-      <p1 x="320" y="720"/>
-      <p2 x="340" y="720"/>
+      <p1 x="320" y="400"/>
+      <p2 x="340" y="400"/>
     </wire>
     <wire>
-      <p1 x="400" y="500"/>
-      <p2 x="440" y="500"/>
+      <p1 x="300" y="340"/>
+      <p2 x="320" y="340"/>
     </wire>
     <wire>
-      <p1 x="520" y="280"/>
-      <p2 x="560" y="280"/>
+      <p1 x="300" y="500"/>
+      <p2 x="320" y="500"/>
     </wire>
     <wire>
-      <p1 x="300" y="280"/>
-      <p2 x="340" y="280"/>
+      <p1 x="420" y="440"/>
+      <p2 x="460" y="440"/>
     </wire>
     <wire>
-      <p1 x="300" y="700"/>
-      <p2 x="340" y="700"/>
+      <p1 x="420" y="280"/>
+      <p2 x="460" y="280"/>
     </wire>
     <wire>
-      <p1 x="140" y="540"/>
-      <p2 x="340" y="540"/>
-    </wire>
-    <wire>
-      <p1 x="420" y="540"/>
-      <p2 x="440" y="540"/>
-    </wire>
-    <wire>
-      <p1 x="140" y="380"/>
-      <p2 x="420" y="380"/>
+      <p1 x="300" y="600"/>
+      <p2 x="320" y="600"/>
     </wire>
     <wire>
       <p1 x="300" y="220"/>
-      <p2 x="340" y="220"/>
+      <p2 x="320" y="220"/>
     </wire>
     <wire>
-      <p1 x="320" y="720"/>
-      <p2 x="320" y="740"/>
+      <p1 x="300" y="380"/>
+      <p2 x="320" y="380"/>
     </wire>
     <wire>
-      <p1 x="420" y="300"/>
-      <p2 x="420" y="380"/>
+      <p1 x="320" y="580"/>
+      <p2 x="320" y="600"/>
     </wire>
     <wire>
-      <p1 x="420" y="540"/>
-      <p2 x="420" y="620"/>
+      <p1 x="320" y="220"/>
+      <p2 x="320" y="240"/>
+    </wire>
+    <wire>
+      <p1 x="320" y="320"/>
+      <p2 x="320" y="340"/>
+    </wire>
+    <wire>
+      <p1 x="320" y="380"/>
+      <p2 x="320" y="400"/>
+    </wire>
+    <wire>
+      <p1 x="320" y="480"/>
+      <p2 x="320" y="500"/>
     </wire>
   </wires>
   <measurementOrdering/>

--- a/src/test/java/de/neemann/digital/integration/TestExamples.java
+++ b/src/test/java/de/neemann/digital/integration/TestExamples.java
@@ -40,8 +40,8 @@ public class TestExamples extends TestCase {
      */
     public void testDistExamples() throws Exception {
         File examples = new File(Resources.getRoot().getParentFile().getParentFile(), "/main/dig");
-        assertEquals(326, new FileScanner(this::check).scan(examples));
-        assertEquals(519, testCasesInFiles);
+        assertEquals(327, new FileScanner(this::check).scan(examples));
+        assertEquals(521, testCasesInFiles);
     }
 
     /**


### PR DESCRIPTION
The .dig file provided for the 7425 chip in the library is missing the strobe pins (see datasheet at [http://www.ti.com/lit/gpn/sn7425](http://www.ti.com/lit/gpn/sn7425) ) A (more modern) 4-way NOR chip without strobe is the 744002.

This PR contains an addition of the strobe pins for the 7425.dig as well as a new file 744002.dig. Both library files have been equipped with test cases. The TestExamples.java has been adjusted accordingly.

Signed-off-by: DerULF1 <github@derulf.net>