### PR TITLE
Add pipette tools

### DIFF
--- a/src/main/java/de/neemann/digital/gui/components/CircuitComponent.java
+++ b/src/main/java/de/neemann/digital/gui/components/CircuitComponent.java
@@ -389,7 +389,7 @@ public class CircuitComponent extends JComponent implements ChangedListener, Lib
                     }
                 }
             }
-        }.setAccelerator("Q").enableAcceleratorIn(this);
+        }.setAccelerator(KeyStroke.getKeyStroke('Q', InputEvent.SHIFT_DOWN_MASK)).enableAcceleratorIn(this);
 
         new ToolTipAction("pipetteCopy") {
             @Override
@@ -402,7 +402,7 @@ public class CircuitComponent extends JComponent implements ChangedListener, Lib
                     }
                 }
             }
-        }.setAccelerator(KeyStroke.getKeyStroke('Q', InputEvent.SHIFT_DOWN_MASK)).enableAcceleratorIn(this);
+        }.setAccelerator("Q").enableAcceleratorIn(this);
 
         ToolTipAction plus = new PlusMinusAction(1).setAccelerator("PLUS").enableAcceleratorIn(this);
         getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_ADD, 0), plus);

--- a/src/main/java/de/neemann/digital/gui/components/CircuitComponent.java
+++ b/src/main/java/de/neemann/digital/gui/components/CircuitComponent.java
@@ -322,7 +322,7 @@ public class CircuitComponent extends JComponent implements ChangedListener, Lib
         }
     }
 
-    private void createAdditionalShortcuts(ShapeFactory shapeFactory) {
+    private void createAdditionalShortcuts(final ShapeFactory shapeFactory) {
         new ToolTipAction("diagWire") {
             @Override
             public void actionPerformed(ActionEvent e) {
@@ -376,6 +376,33 @@ public class CircuitComponent extends JComponent implements ChangedListener, Lib
                 }
             }
         }.setAccelerator("T").enableAcceleratorIn(this);
+
+        new ToolTipAction("pipette") {
+            @Override
+            public void actionPerformed(ActionEvent actionEvent) {
+                if (activeMouseController == mouseNormal) {
+                    VisualElement ve = getActualVisualElement();
+                    if (ve != null) {
+                        // Insert the element using default attributes.
+                        VisualElement insert = new VisualElement(ve.getElementName()).setShapeFactory(shapeFactory);
+                        setPartToInsert(insert);
+                    }
+                }
+            }
+        }.setAccelerator("Q").enableAcceleratorIn(this);
+
+        new ToolTipAction("pipetteCopy") {
+            @Override
+            public void actionPerformed(ActionEvent actionEvent) {
+                if (activeMouseController == mouseNormal) {
+                    VisualElement ve = getActualVisualElement();
+                    if (ve != null) {
+                        // Insert a copy of the element, retaining the attributes.
+                        setPartToInsert(new VisualElement(ve));
+                    }
+                }
+            }
+        }.setAccelerator(KeyStroke.getKeyStroke('Q', InputEvent.SHIFT_DOWN_MASK)).enableAcceleratorIn(this);
 
         ToolTipAction plus = new PlusMinusAction(1).setAccelerator("PLUS").enableAcceleratorIn(this);
         getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_ADD, 0), plus);

--- a/src/main/java/de/neemann/digital/gui/components/CircuitComponent.java
+++ b/src/main/java/de/neemann/digital/gui/components/CircuitComponent.java
@@ -322,7 +322,7 @@ public class CircuitComponent extends JComponent implements ChangedListener, Lib
         }
     }
 
-    private void createAdditionalShortcuts(final ShapeFactory shapeFactory) {
+    private void createAdditionalShortcuts(ShapeFactory shapeFactory) {
         new ToolTipAction("diagWire") {
             @Override
             public void actionPerformed(ActionEvent e) {


### PR DESCRIPTION
Inspired by factory building games such as Factorio, this tool allows you to press `q` when hovering over an element to select that element for placement. It's a small quality of life feature that makes building circuits a bit easier. It features both a `q` action that inserts the element with a copy of the attributes, and a `shift + q` action that inserts the element with default attributes. Opted not to go for `ctrl + q` as on Macs that didn't seem like the best shortcut to use.