### PR TITLE
Add shift click to continue placing elements

### DIFF
--- a/src/main/java/de/neemann/digital/gui/components/CircuitComponent.java
+++ b/src/main/java/de/neemann/digital/gui/components/CircuitComponent.java
@@ -1862,7 +1862,10 @@ public class CircuitComponent extends JComponent implements ChangedListener, Lib
                 modify(new ModifyInsertElement(element));
                 insertWires(element);
             }
-            mouseNormal.activate();
+            // Let shift clicking be used to easily place multiple elements.
+            if (!e.isShiftDown()) {
+                mouseNormal.activate();
+            }
         }
 
         @Override
@@ -1959,7 +1962,12 @@ public class CircuitComponent extends JComponent implements ChangedListener, Lib
                     insertWires(visualElement);
                 }
             }
-            mouseNormal.activate();
+            if (e.isShiftDown()) {
+                // Let shift clicking be used to continue placing copies of the element.
+                setPartToInsert(new VisualElement(visualElement));
+            } else {
+                mouseNormal.activate();
+            }
         }
 
         @Override


### PR DESCRIPTION
Another small quality of life improvement when building circuits. If you hold shift while placing an element, the element remains available for further placement. This allows you to rapidly place multiple copies of the element without having to go in and out of insert mode. When moving an element, shift clicking will switch to insert mode with a copy of that element. Works especially well in combination with the pipette tools.