### PR TITLE
Improve build reproducibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,8 @@
 
     <properties>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
-        <build.timestamp>${maven.build.timestamp}</build.timestamp>
+        <buildTimestamp>${maven.build.timestamp}</buildTimestamp> <!-- cmdline-overridable timestamp for use within pom.xml -->
+        <build.timestamp>${buildTimestamp}</build.timestamp>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.org.slf4j>1.7.24</version.org.slf4j>
     </properties>
@@ -120,7 +121,7 @@
                         </property>
                         <property>
                             <name>buildtime</name>
-                            <value>${maven.build.timestamp}</value>
+                            <value>${buildTimestamp}</value>
                         </property>
                     </systemProperties>
                 </configuration>
@@ -138,7 +139,7 @@
                         </manifest>
                         <manifestEntries>
                             <Build-SCM-Revision>${git.commit.id.describe}</Build-SCM-Revision>
-                            <Build-Time>${maven.build.timestamp}</Build-Time>
+                            <Build-Time>${buildTimestamp}</Build-Time>
                             <SplashScreen-Image>icons/splash.png</SplashScreen-Image>
                         </manifestEntries>
                     </archive>
@@ -203,7 +204,7 @@
                         </manifest>
                         <manifestEntries>
                             <Build-SCM-Revision>${git.commit.id.describe}</Build-SCM-Revision>
-                            <Build-Time>${maven.build.timestamp}</Build-Time>
+                            <Build-Time>${buildTimestamp}</Build-Time>
                             <SplashScreen-Image>icons/splash.png</SplashScreen-Image>
                         </manifestEntries>
                     </archive>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.2.0</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -188,6 +188,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.2.0</version>
                 <configuration>
                     <finalName>Digital</finalName>
                     <appendAssemblyId>false</appendAssemblyId>


### PR DESCRIPTION
Fixes #1090

`mvn verify` runs without error.

Building Digital in a completely reproducible manner is already possible with minor patching, that's what I did to package the application for NixOS [here](https://github.com/NixOS/nixpkgs/pull/209693/files). This PR however makes reproducibility attainable optionally without patching anything, simply by setting a few options on the command line when invoking `mvn`. Two changes were needed:

- update the `jar` and `assembly` plugins to the first version where they support reproducible builds (the chosen versions were suggested automatically by running `mvn artifact:check-buildplan`, see [maven's documentation on reproducibility](https://maven.apache.org/guides/mini/guide-reproducible-builds.html));
- replace every use of `maven.build.timestamp` in pom.xml with an overridable property that defaults to it.

That second part confuses me a bit though as I am not familiar with maven and java build systems in general. I tried to use the already defined `build.timestamp` as the overridable property, but using `-Dbuild.timestamp=...` on maven's command line doesn't seem to change anything, and I can't find what makes this property special. So the only solution I found for now was to create yet another property that I called `buildTimestamp`. I also can't find where this special property is used, the only explicit occurrence of `build.timestamp` in the project seems to be in the Version.txt file, but even I don't set it to the overridden value like this PR does, the build still is reproducible (tested with `mvn clean verify artifact:compare -D...`), is it actually used somewhere?

With this PR, a fully reproducible build of Digital can be achieved by invoking mvn with two options: `-Dproject.build.outputTimestamp=...` (see the [documentation](https://maven.apache.org/guides/mini/guide-reproducible-builds.html) again) and `-DbuildTimestamp=...` to override the build time.

Please do not hesitate to ask me to tweak things as you see fit, to add documentation somewhere or to run more tests, especially as I'm not completely convinced of the cleanliness on this solution.