### PR TITLE
Added ROMDualPort's Verilog export template

### DIFF
--- a/src/main/java/de/neemann/digital/hdl/hgs/Context.java
+++ b/src/main/java/de/neemann/digital/hdl/hgs/Context.java
@@ -171,6 +171,8 @@ public class Context implements HGSMap {
         if (v != null) {
             if (v.getClass().isAssignableFrom(val.getClass()))
                 map.put(name, val);
+            else if (v instanceof Integer && val instanceof Long)
+                map.put(name, Math.toIntExact((Long) val));
             else
                 throw new HGSEvalException("Variable '" + name + "' has wrong type. Needs to be "
                         + v.getClass().getSimpleName() + ", is " + val.getClass().getSimpleName());

--- a/src/main/resources/verilog/DIG_ROMDualPort.v
+++ b/src/main/resources/verilog/DIG_ROMDualPort.v
@@ -16,22 +16,37 @@
     aBitRange := format("[%d:0]", elem.AddrBits - 1);
 
 ?>module <?= moduleName ?> (
-    input <?= aBitRange ?> A,
-    input sel,
-    output reg <?= dBitRange ?> D
+    input <?= aBitRange ?> A1,
+    input <?= aBitRange ?> A2,
+    input s1,
+    input s2,
+    output reg <?= dBitRange ?> D1,
+    output reg <?= dBitRange ?> D2
 );
     reg <?= dBitRange ?> my_rom [0:<?= (romSize - 1) ?>];
 
     always @ (*) begin
-        if (~sel)
-            D = <?= elem.Bits ?>'hz;<?
+        if (~s1)
+            D1 = <?= elem.Bits ?>'hz;<?
         if (romSize < romMaxSize) {
             lastAddr := format("%d'h%x", elem.AddrBits, romSize - 1); ?>
-        else if (A > <?= lastAddr ?>)
-            D = <?= elem.Bits ?>'h0;<?
+        else if (A1 > <?= lastAddr ?>)
+            D1 = <?= elem.Bits ?>'h0;<?
         } ?>
         else
-            D = my_rom[A];
+            D1 = my_rom[A1];
+    end
+
+    always @ (*) begin
+        if (~s2)
+            D2 = <?= elem.Bits ?>'hz;<?
+        if (romSize < romMaxSize) {
+            lastAddr := format("%d'h%x", elem.AddrBits, romSize - 1); ?>
+        else if (A2 > <?= lastAddr ?>)
+            D2 = <?= elem.Bits ?>'h0;<?
+        } ?>
+        else
+            D2 = my_rom[A2];
     end
 
     initial begin<?


### PR DESCRIPTION
1. Allow ROMDualPort components to be exported as Verilog code.
2. Optimize the Verilog export template of existing ROM components to handle the case where ROM data is 0.