### PR TITLE
Add XDG config support

### DIFF
--- a/src/main/java/de/neemann/digital/gui/SettingsBase.java
+++ b/src/main/java/de/neemann/digital/gui/SettingsBase.java
@@ -37,7 +37,11 @@ public class SettingsBase implements AttributeListener {
     protected SettingsBase(List<Key> settingsKeys, String name) {
         this.settingsKeys = settingsKeys;
 
-        filename = new File(new File(System.getProperty("user.home")), name);
+        String settingsDir = System.getenv("XDG_CONFIG_HOME");
+        if (settingsDir == null) {
+            settingsDir = System.getProperty("user.home");
+        }
+        filename = new File(new File(settingsDir), name);
 
         ElementAttributes attr = null;
         if (filename.exists()) {

--- a/src/main/java/de/neemann/digital/gui/SettingsBase.java
+++ b/src/main/java/de/neemann/digital/gui/SettingsBase.java
@@ -37,11 +37,14 @@ public class SettingsBase implements AttributeListener {
     protected SettingsBase(List<Key> settingsKeys, String name) {
         this.settingsKeys = settingsKeys;
 
+        File defaultSettings = new File(new File(System.getProperty("user.home")), name);
         String settingsDir = System.getenv("XDG_CONFIG_HOME");
-        if (settingsDir == null) {
-            settingsDir = System.getProperty("user.home");
+
+        if (defaultSettings.isFile() || settingsDir == null) {
+            filename = defaultSettings;
+        } else {
+            filename = new File(settingsDir, name);
         }
-        filename = new File(new File(settingsDir), name);
 
         ElementAttributes attr = null;
         if (filename.exists()) {


### PR DESCRIPTION
Use XDG_CONFIG_HOME (if defined) to store digital.cfg file instead of HOME. Fixes #1070.

Successfully passes `mvn verify`.