### PR TITLE
Fix module names in export of verilog testbenches

### DIFF
--- a/src/main/java/de/neemann/digital/hdl/verilog2/VerilogGenerator.java
+++ b/src/main/java/de/neemann/digital/hdl/verilog2/VerilogGenerator.java
@@ -87,9 +87,10 @@ public class VerilogGenerator implements Closeable {
             String fileName = out.getFile() != null ? out.getFile().getName() : circuit.getOrigin().getName();
             String[] tokens = fileName.split("(?=(\\.[^\\.]+)$)"); // The power of regex :)
 
-            String topModuleName = vrename.checkName(tokens[0]);
+            String topModuleName = tokens[0];
+            String checkedTopModuleName = vrename.checkName(topModuleName);
 
-            new VerilogCreator(out, library).printHDLCircuit(model.getMain(), topModuleName, model.getRoot());
+            new VerilogCreator(out, library).printHDLCircuit(model.getMain(), checkedTopModuleName, model.getRoot());
 
             File outFile = out.getFile();
             if (outFile != null) {

--- a/src/main/java/de/neemann/digital/hdl/verilog2/VerilogTestBenchCreator.java
+++ b/src/main/java/de/neemann/digital/hdl/verilog2/VerilogTestBenchCreator.java
@@ -105,9 +105,11 @@ public class VerilogTestBenchCreator {
     }
 
     private void writeTestBench(CodePrinter out, String moduleName, String testName, Circuit.TestCase tc) throws IOException, HDLException, TestingDataException, ParserException {
+        HDLModel.Renaming vrename = new VerilogRenaming();
+
         out.print("//  A testbench for ").println(testName);
         out.println("`timescale 1us/1ns").println();
-        out.print("module ").print(testName).println(";");
+        out.print("module ").print(vrename.checkName(testName)).println(";");
 
         // Write local port declaration
         out.inc();
@@ -117,7 +119,8 @@ public class VerilogTestBenchCreator {
         }
 
         out.println();
-        out.print(moduleName).print(" ").print(moduleName).print("0 (").println();
+        out.print(vrename.checkName(moduleName)).print(" ").print(vrename.checkName(moduleName + "0")).print(" (")
+                .println();
         out.inc();
 
         Separator comma = new Separator(out, ",\n");

--- a/src/test/java/de/neemann/digital/hdl/verilog2/VerilogSimulatorTest.java
+++ b/src/test/java/de/neemann/digital/hdl/verilog2/VerilogSimulatorTest.java
@@ -69,6 +69,16 @@ public class VerilogSimulatorTest extends TestCase {
         }
     }
 
+    public void testInSimulatorNames() throws Exception {
+        File examples = new File(Resources.getRoot(), "/dig/hdl_names");
+        try {
+            int tested = new FileScanner(this::checkVerilogExport).noOutput().scan(examples);
+            assertEquals(3, tested);
+        } catch (FileScanner.SkipAllException e) {
+            // if iverilog is not installed its also ok
+        }
+    }
+
     public void testInSimulatorInOut() throws Exception {
         File examples = new File(Resources.getRoot(), "/dig/test/pinControl");
         try {

--- a/src/test/resources/dig/hdl_names/a-b.dig
+++ b/src/test/resources/dig/hdl_names/a-b.dig
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<circuit>
+  <version>2</version>
+  <attributes/>
+  <visualElements>
+    <visualElement>
+      <elementName>And</elementName>
+      <elementAttributes/>
+      <pos x="380" y="200"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Out</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>Y</string>
+        </entry>
+      </elementAttributes>
+      <pos x="460" y="220"/>
+    </visualElement>
+    <visualElement>
+      <elementName>In</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>A</string>
+        </entry>
+      </elementAttributes>
+      <pos x="360" y="200"/>
+    </visualElement>
+    <visualElement>
+      <elementName>In</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Label</string>
+          <string>B</string>
+        </entry>
+      </elementAttributes>
+      <pos x="360" y="240"/>
+    </visualElement>
+    <visualElement>
+      <elementName>Testcase</elementName>
+      <elementAttributes>
+        <entry>
+          <string>Testdata</string>
+          <testData>
+            <dataString>A B Y
+0 0 0
+0 1 0
+1 0 0
+1 1 1
+</dataString>
+          </testData>
+        </entry>
+      </elementAttributes>
+      <pos x="320" y="100"/>
+    </visualElement>
+  </visualElements>
+  <wires>
+    <wire>
+      <p1 x="360" y="240"/>
+      <p2 x="380" y="240"/>
+    </wire>
+    <wire>
+      <p1 x="360" y="200"/>
+      <p2 x="380" y="200"/>
+    </wire>
+    <wire>
+      <p1 x="440" y="220"/>
+      <p2 x="460" y="220"/>
+    </wire>
+  </wires>
+  <measurementOrdering/>
+</circuit>


### PR DESCRIPTION
When exporting verilog testbenches, module names are not properly escaped.

For example, if the file "My-file" contains a test named "My-test" then the module declaration for the testbench will start with `module My-file_My-test_tb;` and the instantiation of the "My-file" module will look like `\My-file  \My-file 0 (...)`. In both cases the hyphen makes the names illegal verilog identifiers.

With this PR you will instead get `module \My-file_My-test_tb ;` and `\My-file  \My-file0  (...)`

I've added a new test file in "src/test/resources/dig/hdl_names/a-b.dig" and two tests that use this file. I'm not sure if this is the nicest way of writing these tests