### PR TITLE
Bug Fix | Custom java component not loading properly

### DIFF
--- a/src/main/java/de/neemann/digital/draw/library/ElementLibrary.java
+++ b/src/main/java/de/neemann/digital/draw/library/ElementLibrary.java
@@ -286,6 +286,7 @@ public class ElementLibrary implements Iterable<ElementLibrary.ElementContainer>
             if (jarComponentManager == null)
                 jarComponentManager = new JarComponentManager(this);
             source.registerComponents(jarComponentManager);
+            rescanFolder();
         } catch (InvalidNodeException e) {
             exception = e;
         }

--- a/src/test/java/de/neemann/digital/draw/library/JarComponentManagerTest.java
+++ b/src/test/java/de/neemann/digital/draw/library/JarComponentManagerTest.java
@@ -13,6 +13,14 @@ import junit.framework.TestCase;
 
 import java.io.File;
 
+import de.neemann.digital.core.Model;
+import de.neemann.digital.core.NodeException;
+import de.neemann.digital.core.ObservableValues;
+import de.neemann.digital.core.element.Element;
+import de.neemann.digital.core.element.ElementAttributes;
+import de.neemann.digital.core.element.ElementTypeDescription;
+import de.neemann.digital.core.element.Keys;
+
 public class JarComponentManagerTest extends TestCase {
 
     public void testMissingJar() throws Exception {
@@ -28,12 +36,68 @@ public class JarComponentManagerTest extends TestCase {
         ToBreakRunner br = new ToBreakRunner("dig/jarLib/jarLibTest.dig") {
             @Override
             public void initLibrary(ElementLibrary library) {
-                library.addExternalJarComponents(new File(Resources.getRoot(), "dig/jarLib/pluginExample-1.0-SNAPSHOT.jar"));
+                library.addExternalJarComponents(
+                        new File(Resources.getRoot(), "dig/jarLib/pluginExample-1.0-SNAPSHOT.jar"));
                 assertNull(library.checkForException());
             }
         };
 
         for (Circuit.TestCase tc : br.getCircuit().getTestCases())
             assertTrue(new TestExecutor(tc, br.getCircuit(), br.getLibrary()).execute().allPassed());
+    }
+
+    public void testJarDebug() throws Exception {
+        ElementLibrary library = new ElementLibrary();
+        library.registerComponentSource(new CustomTestComponentSource());
+        LibraryNode component = library.getElementNodeOrNull("CustomTestComponent");
+        assertTrue(component instanceof LibraryNode);
+        assertEquals(component.getName(), "CustomTestComponent");
+        
+        
+    }
+
+    private static class CustomTestComponent implements Element {
+
+        /**
+         * Custom test component description
+         */
+        public static final ElementTypeDescription DESCRIPTION = new ElementTypeDescription("CustomTestComponent",
+                CustomTestComponent.class)
+                .addAttribute(Keys.LABEL);
+
+        /**
+         * Creates a new custom test component
+         *
+         * @param attr the attributes
+         */
+        @SuppressWarnings("unused")
+        public CustomTestComponent(ElementAttributes attr) {
+        }
+
+        @Override
+        public void setInputs(ObservableValues inputs) throws NodeException {
+        }
+
+        @Override
+        public ObservableValues getOutputs() {
+            return ObservableValues.EMPTY_LIST;
+        }
+
+        @Override
+        public void registerNodes(Model model) {
+        }
+    }
+
+    private static class CustomTestComponentSource implements ComponentSource {
+
+        /**
+         * Registers custom test component to component library
+         */
+        @Override
+        public void registerComponents(ComponentManager manager) throws InvalidNodeException {
+
+            manager.addComponent("CustomTestComponentsLibrary", CustomTestComponent.DESCRIPTION);
+
+        }
     }
 }


### PR DESCRIPTION
When debugging custom components, Digital does not let the user use custom Java components, unless Digital is opened with a file or has some file in its history. This is explained in depth in the issue, and the discussion linked below.

Tests were written to cover this case too.

fixes #1315 
closes #1312 