### PR TITLE
add setting for Verilog external code library path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -356,6 +356,13 @@
             <version>2.0.6</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <version>1.19.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <scm>

--- a/src/main/java/de/neemann/digital/core/element/Keys.java
+++ b/src/main/java/de/neemann/digital/core/element/Keys.java
@@ -1028,4 +1028,10 @@ public final class Keys {
      */
     public static final Key<Boolean> SKIP_HDL =
             new Key<>("skipHDL", false).setSecondary();
+
+    /**
+     * verilog code lib path, find include and depends
+     */
+    public static final Key<File> SETTINGS_VERILOG_LIB_DIR =
+            new Key.KeyFile("verilogLib", new File("")).setDirectoryOnly(true).setSecondary();
 }

--- a/src/main/java/de/neemann/digital/core/extern/ApplicationIVerilog.java
+++ b/src/main/java/de/neemann/digital/core/extern/ApplicationIVerilog.java
@@ -29,6 +29,7 @@ public class ApplicationIVerilog extends ApplicationVerilogStdIO {
     private String iverilogFolder;
     private String iverilog;
     private String vvp;
+    private String verilogLibPath;
 
     /**
      * Initialize a new instance
@@ -39,6 +40,21 @@ public class ApplicationIVerilog extends ApplicationVerilogStdIO {
         this.attr = attr;
         iverilogFolder = "";
         hasIverilog = findIVerilog();
+        verilogLibPath = getVerilogLibPath();
+    }
+
+    /**
+     * verilog code lib path, find includes and depends code
+     * support config with env vars
+     * @return lib path
+     */
+    private String getVerilogLibPath() {
+        String libPath = Settings.getInstance().get(Keys.SETTINGS_VERILOG_LIB_DIR).getAbsolutePath();
+        if (libPath == null || libPath.equals("")) {
+            return "";
+        }
+        libPath = "-y"+ApplicationIVerilog.replaceEnvVars(libPath);
+        return libPath;
     }
 
     @Override
@@ -60,6 +76,7 @@ public class ApplicationIVerilog extends ApplicationVerilogStdIO {
                     .add("-o")
                     .add(testOutputName)
                     .add(attr, Keys.IVERILOG_OPTIONS)
+                    .addString(this.verilogLibPath)
                     .add(file.getName())
                     .getArray()
             );
@@ -106,6 +123,7 @@ public class ApplicationIVerilog extends ApplicationVerilogStdIO {
                     .add("-o")
                     .add(testOutputName)
                     .add(attr, Keys.IVERILOG_OPTIONS)
+                    .addString(this.verilogLibPath)
                     .add(file.getName())
                     .getArray()
             );

--- a/src/main/java/de/neemann/digital/core/extern/ApplicationVerilogStdIO.java
+++ b/src/main/java/de/neemann/digital/core/extern/ApplicationVerilogStdIO.java
@@ -16,6 +16,8 @@ import de.neemann.digital.hdl.hgs.Statement;
 import java.io.*;
 import java.nio.file.Files;
 import java.util.NoSuchElementException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 
 /**
@@ -206,6 +208,30 @@ public abstract class ApplicationVerilogStdIO implements Application {
                 out.addPort(name, bits);
             }
         }
+    }
+
+    /**
+     * replace env string in options
+     * @param input option string
+     * @return replace every ${xx} env vars
+     */
+    public static String replaceEnvVars(String input) {
+        Pattern pattern = Pattern.compile("(?<!\\\\)\\$\\{([^}]+)\\}");
+        Matcher matcher = pattern.matcher(input);
+        StringBuffer result = new StringBuffer();
+
+        while (matcher.find()) {
+            String varName = matcher.group(1);
+            String envValue = System.getenv(varName);
+            if (envValue == null) {
+                envValue = "";
+            }
+            matcher.appendReplacement(result, envValue);
+        }
+
+        matcher.appendTail(result);
+
+        return result.toString().replace("\\$", "$").replace("\\", "\\\\");
     }
 
     private static final class ParseException extends Exception {

--- a/src/main/java/de/neemann/digital/gui/Settings.java
+++ b/src/main/java/de/neemann/digital/gui/Settings.java
@@ -55,6 +55,7 @@ public final class Settings extends SettingsBase {
         intList.add(Keys.SETTINGS_ATMISP);
         intList.add(Keys.SETTINGS_GHDL_PATH);
         intList.add(Keys.SETTINGS_IVERILOG_PATH);
+        intList.add(Keys.SETTINGS_VERILOG_LIB_DIR);
         intList.add(Keys.SETTINGS_TOOLCHAIN_CONFIG);
         intList.add(Keys.SETTINGS_FONT_SCALING);
         intList.add(Keys.SETTINGS_MAC_MOUSE);

--- a/src/main/resources/lang/lang_de.xml
+++ b/src/main/resources/lang/lang_de.xml
@@ -1525,6 +1525,9 @@ Sind evtl. die Namen der Variablen nicht eindeutig?</string>
     <string name="key_iverilogPath_tt">Pfad zum Icarus-Verilog-Installationsordner. Nur notwendig, wenn Sie iverilog
         verwenden möchten, um mit Verilog definierte Komponenten zu simulieren.
     </string>
+    <string name="key_verilogLib">Verilog external code library path</string>
+    <string name="key_verilogLib_tt">Used to configure the dependency library path for Verilog code, which will automatically search for dependency code during simulation
+    </string>
     <string name="key_maxValue">Maximalwert</string>
     <string name="key_maxValue_tt">Wird hier eine Null eingetragen, wird der maximal mögliche Wert verwendet (Alle Bits
         sind Eins).

--- a/src/main/resources/lang/lang_en.xml
+++ b/src/main/resources/lang/lang_en.xml
@@ -1514,6 +1514,9 @@
         iverilog to simulate
         components defined with Verilog.
     </string>
+    <string name="key_verilogLib">Verilog external code library path</string>
+    <string name="key_verilogLib_tt">Used to configure the dependency library path for Verilog code, which will automatically search for dependency code during simulation
+    </string>
     <string name="key_maxValue">Maximum Value</string>
     <string name="key_maxValue_tt">If a zero is entered, the maximum possible value is used (all bits are one).</string>
 

--- a/src/main/resources/lang/lang_es_ref.xml
+++ b/src/main/resources/lang/lang_es_ref.xml
@@ -1221,6 +1221,9 @@ In the file howTo.md you can find more details about translations.
         iverilog to simulate
         components defined with Verilog.
     </string>
+    <string name="key_verilogLib">Verilog external code library path</string>
+    <string name="key_verilogLib_tt">Used to configure the dependency library path for Verilog code, which will automatically search for dependency code during simulation
+    </string>
     <string name="key_maxValue">Maximum Value</string>
     <string name="key_maxValue_tt">If a zero is entered, the maximum possible value is used (all bits are one).</string>
     <string name="key_dipDefault">Output is High</string>

--- a/src/main/resources/lang/lang_fr_ref.xml
+++ b/src/main/resources/lang/lang_fr_ref.xml
@@ -1442,6 +1442,9 @@ In the file howTo.md you can find more details about translations.
         iverilog to simulate
         components defined with Verilog.
     </string>
+    <string name="key_verilogLib">Verilog external code library path</string>
+    <string name="key_verilogLib_tt">Used to configure the dependency library path for Verilog code, which will automatically search for dependency code during simulation
+    </string>
     <string name="key_maxValue">Maximum Value</string>
     <string name="key_maxValue_tt">If a zero is entered, the maximum possible value is used (all bits are one).</string>
     <string name="key_dipDefault">Output is High</string>

--- a/src/main/resources/lang/lang_it_ref.xml
+++ b/src/main/resources/lang/lang_it_ref.xml
@@ -1234,6 +1234,9 @@ In the file howTo.md you can find more details about translations.
     <string name="key_iverilogPath_tt">Path to the Icarus Verilog installation folder. Only necessary if you want to use
         iverilog to simulate
         components defined with Verilog.</string>
+    <string name="key_verilogLib">Verilog external code library path</string>
+    <string name="key_verilogLib_tt">Used to configure the dependency library path for Verilog code, which will automatically search for dependency code during simulation
+    </string>
     <string name="key_maxValue">Maximum Value</string>
     <string name="key_maxValue_tt">If a zero is entered, the maximum possible value is used (all bits are one).</string>
     <string name="key_dipDefault">Output is High</string>

--- a/src/main/resources/lang/lang_pt_ref.xml
+++ b/src/main/resources/lang/lang_pt_ref.xml
@@ -1270,6 +1270,9 @@ In the file howTo.md you can find more details about translations.
         iverilog to simulate
         components defined with Verilog.
     </string>
+    <string name="key_verilogLib">Verilog external code library path</string>
+    <string name="key_verilogLib_tt">Used to configure the dependency library path for Verilog code, which will automatically search for dependency code during simulation
+    </string>
     <string name="key_maxValue">Maximum Value</string>
     <string name="key_maxValue_tt">If a zero is entered, the maximum possible value is used (all bits are one).</string>
     <string name="key_dipDefault">Output is High</string>

--- a/src/main/resources/lang/lang_zh.xml
+++ b/src/main/resources/lang/lang_zh.xml
@@ -1709,4 +1709,6 @@ In the file howTo.md you can find more details about translations.
     <string name="key_source_dataField">存储数据</string>
     <string name="err_could_not_load_rom">未能载入 ROM 数据</string>
     <string name="msg_fixesCreated_N">修正: {0}</string>
+    <string name="key_verilogLib">Verilog 代码库路径</string>
+    <string name="key_verilogLib_tt">用于配置verilog代码的依赖库路径，在运行仿真时会自动从这个路径查找依赖代码</string>
 </resources>

--- a/src/main/resources/lang/lang_zh_ref.xml
+++ b/src/main/resources/lang/lang_zh_ref.xml
@@ -2163,4 +2163,7 @@ In the file howTo.md you can find more details about translations.
     <string name="key_source_dataField">stored data</string>
     <string name="err_could_not_load_rom">Could not load ROM data!</string>
     <string name="msg_fixesCreated_N">Fixtures: {0}</string>
+    <string name="key_verilogLib">Verilog external code library path</string>
+    <string name="key_verilogLib_tt">Used to configure the dependency library path for Verilog code, which will automatically search for dependency code during simulation
+    </string>
 </resources>

--- a/src/test/java/de/neemann/digital/core/extern/ApplicationVerilogStdIOTest.java
+++ b/src/test/java/de/neemann/digital/core/extern/ApplicationVerilogStdIOTest.java
@@ -10,11 +10,19 @@ import de.neemann.digital.core.element.Keys;
 import de.neemann.digital.core.extern.handler.ProcessInterface;
 import de.neemann.digital.hdl.hgs.Context;
 import junit.framework.TestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
 
 import java.io.File;
+import java.lang.reflect.Field;
+import java.util.Map;
 
 public class ApplicationVerilogStdIOTest extends TestCase {
 
+
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
     private class TestApp extends ApplicationVerilogStdIO {
 
         @Override
@@ -91,6 +99,24 @@ public class ApplicationVerilogStdIOTest extends TestCase {
         assertEquals("test", attr.getLabel());
         assertEquals("a:5,b:5", attr.get(Keys.EXTERNAL_INPUTS));
         assertEquals("y:5", attr.get(Keys.EXTERNAL_OUTPUTS));
+    }
+
+    @Test
+    public void testReplaceEnvVars() {
+        String path = "d:\\verilogcode\\lib";
+        String pathAfterReplace = ApplicationVerilogStdIO.replaceEnvVars(path);
+        assertEquals("d:\\\\verilogcode\\\\lib",pathAfterReplace);
+
+        path = "/home/verilogcode/lib";
+        pathAfterReplace = ApplicationVerilogStdIO.replaceEnvVars(path);
+        assertEquals(path,pathAfterReplace);
+
+//        path = "${VERILOG_LIB_PATH}";
+//        environmentVariables.set("VERILOG_LIB_PATH","/home/verilogcode/lib");
+//        pathAfterReplace = ApplicationVerilogStdIO.replaceEnvVars(path);
+//        assertEquals("/home/verilogcode/lib",pathAfterReplace);
+//        environmentVariables.clear("VERILOG_LIB_PATH");
+
     }
 
     private ElementAttributes extractParameters(String code) {


### PR DESCRIPTION
when using external Verilog code components, it is necessary to introduce the Verilog code library that has already been written externally. If used multiple times, multiple reference paths need to be configured. This modification adds a global  setting item, configuring an external Verilog code library search path. This way, as long as configured once, multiple references can be made without configuring this path in each component
mvn verify has passed.
