### PR TITLE
Fix #1351 Java application execution on Wayland by setting JAVA_TOOL_OPTIONS

### DIFF
--- a/distribution/linux/Digital.sh
+++ b/distribution/linux/Digital.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 DIR="$( cd "$( dirname "$( realpath "${BASH_SOURCE[0]}" )" )" >/dev/null && pwd )"
+export JAVA_TOOL_OPTIONS='-Djava.awt.headless=false'
 java -jar "$DIR/Digital.jar" "$1"


### PR DESCRIPTION
# Description:
This pull request addresses an issue #1351 , where the Java application fails to start on Wayland due to headless mode errors. To resolve this, I added the following environment variable to `Digital.sh` before executing the application:

```bash

export JAVA_TOOL_OPTIONS='-Djava.awt.headless=false'
```
This ensures that the Java AWT is not treated as headless when running in Wayland environments.

# Changes:

Updated `Digital.sh` to include `JAVA_TOOL_OPTIONS='-Djava.awt.headless=false'`.

# OpenJDK Version:

Issue was resolved after updating from OpenJDK 17 to OpenJDK 21.

# Testing:

Verified functionality on both Wayland and X11. The application runs smoothly without errors in both setups, confirming that the change does not negatively impact execution under X11.

# Additional Information:

- This fix ensures compatibility with Wayland while maintaining existing functionality for X11 users.
- Updating to OpenJDK 21 is recommended as the issue persists in version 17.