### PR TITLE
Stop merging of Wires if they are connected to a Pin

### DIFF
--- a/src/main/java/de/neemann/digital/draw/elements/Circuit.java
+++ b/src/main/java/de/neemann/digital/draw/elements/Circuit.java
@@ -356,7 +356,7 @@ public class Circuit implements Copyable<Circuit> {
             return null;
 
         wires.add(newWire);
-        WireConsistencyChecker checker = new WireConsistencyChecker(wires);
+        WireConsistencyChecker checker = new WireConsistencyChecker(wires, visualElements);
         wires = checker.check();
 
         dotsPresent = false;
@@ -371,7 +371,7 @@ public class Circuit implements Copyable<Circuit> {
      */
     public Circuit add(ArrayList<Wire> newWires) {
         wires.addAll(newWires);
-        WireConsistencyChecker checker = new WireConsistencyChecker(wires);
+        WireConsistencyChecker checker = new WireConsistencyChecker(wires, visualElements);
         wires = checker.check();
 
         dotsPresent = false;
@@ -382,7 +382,7 @@ public class Circuit implements Copyable<Circuit> {
      * Called if elements are moved
      */
     public void elementsMoved() {
-        WireConsistencyChecker checker = new WireConsistencyChecker(wires);
+        WireConsistencyChecker checker = new WireConsistencyChecker(wires, visualElements);
         wires = checker.check();
 
         dotsPresent = false;
@@ -627,7 +627,7 @@ public class Circuit implements Copyable<Circuit> {
         }
 
         if (wireDeleted) {
-            WireConsistencyChecker checker = new WireConsistencyChecker(wires);
+            WireConsistencyChecker checker = new WireConsistencyChecker(wires, visualElements);
             wires = checker.check();
         }
 
@@ -650,7 +650,7 @@ public class Circuit implements Copyable<Circuit> {
      */
     public void delete(Wire wireToDelete) {
         if (wires.remove(wireToDelete)) {
-            WireConsistencyChecker checker = new WireConsistencyChecker(wires);
+            WireConsistencyChecker checker = new WireConsistencyChecker(wires, visualElements);
             wires = checker.check();
             dotsPresent = false;
         }

--- a/src/main/java/de/neemann/digital/draw/elements/WireConsistencyChecker.java
+++ b/src/main/java/de/neemann/digital/draw/elements/WireConsistencyChecker.java
@@ -16,14 +16,17 @@ import java.util.HashSet;
  */
 public class WireConsistencyChecker {
     private ArrayList<Wire> wires;
+    private ArrayList<VisualElement> elements;
 
     /**
      * Creates a new instance
      *
-     * @param wires the wires to check
+     * @param wires    the wires to check
+     * @param elements the VisualElements which may have a connection to the wires
      */
-    public WireConsistencyChecker(ArrayList<Wire> wires) {
+    public WireConsistencyChecker(ArrayList<Wire> wires, ArrayList<VisualElement> elements) {
         this.wires = wires;
+        this.elements = elements;
     }
 
     /**
@@ -41,6 +44,11 @@ public class WireConsistencyChecker {
         HashSet<Vector> horiPoints = new HashSet<>();
         HashSet<Vector> vertPoints = new HashSet<>();
         HashSet<Vector> diagPoints = new HashSet<>();
+        HashSet<Vector> allElemPoints = new HashSet<>();
+        for (VisualElement e : elements)
+            for (Pin p : e.getPins())
+                allElemPoints.add(p.getPos());
+        HashSet<Vector> elemPoints = new HashSet<>();
 
         ArrayList<Wire> newWires = new ArrayList<>();
         WireMerger hori = new WireMerger(Wire.Orientation.horizontal);
@@ -68,10 +76,18 @@ public class WireConsistencyChecker {
                 }
         }
 
+        elemPoints.addAll(diagPoints);
+        elemPoints.addAll(vertPoints);
+        elemPoints.addAll(horiPoints);
+        elemPoints.retainAll(allElemPoints);
+
+
         hori.protectPoints(diagPoints);
         hori.protectPoints(vertPoints);
+        hori.protectPoints(elemPoints);
         vert.protectPoints(diagPoints);
         vert.protectPoints(horiPoints);
+        vert.protectPoints(elemPoints);
 
         hori.addTo(newWires);
         vert.addTo(newWires);

--- a/src/test/java/de/neemann/digital/draw/elements/WireConsistencyCheckerTest.java
+++ b/src/test/java/de/neemann/digital/draw/elements/WireConsistencyCheckerTest.java
@@ -5,10 +5,17 @@
  */
 package de.neemann.digital.draw.elements;
 
+import de.neemann.digital.core.element.Keys;
+import de.neemann.digital.core.io.Out;
 import de.neemann.digital.draw.graphics.Vector;
+import de.neemann.digital.draw.library.ElementLibrary;
+import de.neemann.digital.draw.shapes.ShapeFactory;
 import junit.framework.TestCase;
 
 import java.util.ArrayList;
+
+import static de.neemann.digital.draw.graphics.Vector.vec;
+import static de.neemann.digital.draw.shapes.GenericShape.SIZE;
 
 /**
  */
@@ -19,8 +26,9 @@ public class WireConsistencyCheckerTest extends TestCase {
         wires.add(new Wire(new Vector(0, 0), new Vector(10, 0)));
         wires.add(new Wire(new Vector(10, 0), new Vector(10, 10)));
         wires.add(new Wire(new Vector(10, 0), new Vector(20, 0)));
+        ArrayList<VisualElement> visualElements = new ArrayList<>();
 
-        wires = new WireConsistencyChecker(wires).check();
+        wires = new WireConsistencyChecker(wires, visualElements).check();
 
         assertEquals(3, wires.size());
         checkContains(wires, new Wire(new Vector(0, 0), new Vector(10, 0)));
@@ -33,8 +41,9 @@ public class WireConsistencyCheckerTest extends TestCase {
         wires.add(new Wire(new Vector(0, 0), new Vector(10, 0)));
         wires.add(new Wire(new Vector(10, 0), new Vector(10, 10)));
         wires.add(new Wire(new Vector(0, 0), new Vector(20, 0)));
+        ArrayList<VisualElement> visualElements = new ArrayList<>();
 
-        wires = new WireConsistencyChecker(wires).check();
+        wires = new WireConsistencyChecker(wires, visualElements).check();
 
         assertEquals(3, wires.size());
         checkContains(wires, new Wire(new Vector(0, 0), new Vector(10, 0)));
@@ -48,8 +57,9 @@ public class WireConsistencyCheckerTest extends TestCase {
         wires.add(new Wire(new Vector(10, 0), new Vector(20, 0)));
         wires.add(new Wire(new Vector(10, 0), new Vector(10, 10)));
         wires.add(new Wire(new Vector(10, 0), new Vector(10, -10)));
+        ArrayList<VisualElement> visualElements = new ArrayList<>();
 
-        wires = new WireConsistencyChecker(wires).check();
+        wires = new WireConsistencyChecker(wires, visualElements).check();
 
         assertEquals(4, wires.size());
         checkContains(wires, new Wire(new Vector(0, 0), new Vector(10, 0)));
@@ -62,12 +72,41 @@ public class WireConsistencyCheckerTest extends TestCase {
         ArrayList<Wire> wires = new ArrayList<>();
         wires.add(new Wire(new Vector(0, 10), new Vector(20, 10)));
         wires.add(new Wire(new Vector(10, 0), new Vector(10, 20)));
+        ArrayList<VisualElement> visualElements = new ArrayList<>();
 
-        wires = new WireConsistencyChecker(wires).check();
+        wires = new WireConsistencyChecker(wires, visualElements).check();
 
         assertEquals(2, wires.size());
         checkContains(wires, new Wire(new Vector(0, 10), new Vector(20, 10)));
         checkContains(wires, new Wire(new Vector(10, 0), new Vector(10, 20)));
+    }
+
+    public void testCheck5() throws Exception {
+        ArrayList<Wire> wires = new ArrayList<>();
+        wires.add(new Wire(new Vector(0, 10), new Vector(0, 20)));
+        wires.add(new Wire(new Vector(0, 20), new Vector(0, 30)));
+        ArrayList<VisualElement> visualElements = new ArrayList<>();
+        visualElements.add(new VisualElement(new VisualElement(Out.DESCRIPTION.getName()).setPos(vec(0, 20))
+                .setAttribute(Keys.LABEL, "out").setShapeFactory(new ShapeFactory(new ElementLibrary()))));
+
+        wires = new WireConsistencyChecker(wires, visualElements).check();
+
+        assertEquals(2, wires.size());
+        checkContains(wires, new Wire(new Vector(0, 10), new Vector(0, 20)));
+        checkContains(wires, new Wire(new Vector(0, 20), new Vector(0, 30)));
+    }
+
+    public void testCheck6() throws Exception {
+        ArrayList<Wire> wires = new ArrayList<>();
+        wires.add(new Wire(new Vector(0, 10), new Vector(0, 30)));
+        ArrayList<VisualElement> visualElements = new ArrayList<>();
+        visualElements.add(new VisualElement(new VisualElement(Out.DESCRIPTION.getName()).setPos(vec(0, 20))
+                .setAttribute(Keys.LABEL, "out").setShapeFactory(new ShapeFactory(new ElementLibrary()))));
+
+        wires = new WireConsistencyChecker(wires, visualElements).check();
+
+        assertEquals(1, wires.size());
+        checkContains(wires, new Wire(new Vector(0, 10), new Vector(0, 30)));
     }
 
     public static void checkContains(ArrayList<Wire> wires, Wire wire) {

--- a/src/test/java/de/neemann/digital/draw/shapes/custom/CustomShapeDescriptionTest.java
+++ b/src/test/java/de/neemann/digital/draw/shapes/custom/CustomShapeDescriptionTest.java
@@ -13,6 +13,8 @@ import de.neemann.digital.draw.elements.Circuit;
 import de.neemann.digital.draw.elements.PinException;
 import de.neemann.digital.draw.elements.VisualElement;
 import de.neemann.digital.draw.elements.Wire;
+import de.neemann.digital.draw.library.ElementLibrary;
+import de.neemann.digital.draw.shapes.ShapeFactory;
 import de.neemann.digital.draw.shapes.custom.svg.SvgException;
 import de.neemann.digital.draw.shapes.custom.svg.SvgImporter;
 import junit.framework.TestCase;
@@ -37,8 +39,10 @@ public class CustomShapeDescriptionTest extends TestCase {
 
     public void testCheckCompatibilityOk() throws PinException {
         Circuit circuit = new Circuit()
-                .add(new VisualElement(In.DESCRIPTION.getName()).setPos(vec(0, 0)).setAttribute(Keys.LABEL, "in"))
-                .add(new VisualElement(Out.DESCRIPTION.getName()).setPos(vec(20, 0)).setAttribute(Keys.LABEL, "out"))
+                .add(new VisualElement(In.DESCRIPTION.getName()).setPos(vec(0, 0)).setAttribute(Keys.LABEL, "in")
+                        .setShapeFactory(new ShapeFactory(new ElementLibrary())))
+                .add(new VisualElement(Out.DESCRIPTION.getName()).setPos(vec(20, 0)).setAttribute(Keys.LABEL, "out")
+                        .setShapeFactory(new ShapeFactory(new ElementLibrary())))
                 .add(new Wire(vec(0, 0), vec(20, 0)));
 
         custom.checkCompatibility(circuit);
@@ -46,8 +50,10 @@ public class CustomShapeDescriptionTest extends TestCase {
 
     public void testCheckCompatibilityClock() throws PinException {
         Circuit circuit = new Circuit()
-                .add(new VisualElement(Clock.DESCRIPTION.getName()).setPos(vec(0, 0)).setAttribute(Keys.LABEL, "in"))
-                .add(new VisualElement(Out.DESCRIPTION.getName()).setPos(vec(20, 0)).setAttribute(Keys.LABEL, "out"))
+                .add(new VisualElement(Clock.DESCRIPTION.getName()).setPos(vec(0, 0)).setAttribute(Keys.LABEL, "in")
+                        .setShapeFactory(new ShapeFactory(new ElementLibrary())))
+                .add(new VisualElement(Out.DESCRIPTION.getName()).setPos(vec(20, 0)).setAttribute(Keys.LABEL, "out")
+                        .setShapeFactory(new ShapeFactory(new ElementLibrary())))
                 .add(new Wire(vec(0, 0), vec(20, 0)));
 
         custom.checkCompatibility(circuit);


### PR DESCRIPTION
Fixes #1363 
Change Constructor of WireConsistencyChecker to always need VisualElements
Changed Circuit to always include visualElements 
Added TestCases for WireConsistencyCheckerTest
Modified CustomShapeDescriptionTest so there will not be a NullPointerException
Only added a WireBreak where there already was a connection with a Pin
