### PR TITLE
remove dead link from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ Prior to the development of Digital, I used [Logisim](http://www.cburch.com/logi
 If you are familiar with Logisim you will recognize the wire color scheme.
 
 Logisim is a excellent and proven tool for teaching purposes, that has been actively developed until 2011. 
-In 2013 Carl Burch has started the development of a new simulator called [Toves](http://www.toves.org/). 
-In his [blog](http://www.toves.org/blog/) he explained why he decided to develop a new simulator instead of improving Logisim. 
+In 2013 Carl Burch has started the development of a new simulator called Toves. 
+In his blog he explained why he decided to develop a new simulator instead of improving Logisim. 
 In short: In his opinion, there are weaknesses in Logisim's architecture that are too difficult to overcome. 
 Unfortunately, the development of Toves was discontinued at a very early stage.
 


### PR DESCRIPTION
The URL [toves.org](http://toves.org) now only leads to a gambling website.
It is better to remove it.