### PR TITLE
Italian language correction for fsm set action

### DIFF
--- a/src/main/resources/lang/lang_it.xml
+++ b/src/main/resources/lang/lang_it.xml
@@ -1942,7 +1942,7 @@ Comunque, non devono trovarsi sopra la riga di intestazione che elenca i nomi de
     <string name="fsm_noMove">Nessun movimento</string>
     <string name="fsm_moveTrans">Transizioni</string>
     <string name="fsm_moveStates">Transizioni e Stati</string>
-    <string name="fsm_set_N">insieme {0}</string>
+    <string name="fsm_set_N">imposta {0}</string>
     <string name="menu_fsm">Macchina a Stati Finiti</string>
     <string name="menu_fsm_tt">Apre una finestra di dialogo per modificare una macchina a stati finiti.</string>
     <string name="menu_fsm_create">Crea</string>


### PR DESCRIPTION
Change in the Italian language translation: the FSM action option was uncorrectly translated to "insieme" which stands for English "set" as in "numerical set". Now it's translated to "imposta" which is the correct form.