### PR TITLE
Introduce the LengthExport CLI command

### DIFF
--- a/src/main/java/de/neemann/digital/cli/LengthExport.java
+++ b/src/main/java/de/neemann/digital/cli/LengthExport.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Alessandro Pellegrini.
+ * Use of this source code is governed by the GPL v3 license
+ * that can be found in the LICENSE file.
+ */
+package de.neemann.digital.cli;
+
+import de.neemann.digital.analyse.AnalyseException;
+import de.neemann.digital.analyse.ModelAnalyser;
+import de.neemann.digital.analyse.PathLenAnalyser;
+import de.neemann.digital.cli.cli.Argument;
+import de.neemann.digital.cli.cli.BasicCommand;
+import de.neemann.digital.cli.cli.CLIException;
+import de.neemann.digital.core.BacktrackException;
+import de.neemann.digital.core.Model;
+import de.neemann.digital.core.NodeException;
+import de.neemann.digital.draw.elements.PinException;
+import de.neemann.digital.draw.library.ElementNotFoundException;
+import de.neemann.digital.lang.Lang;
+
+import java.io.IOException;
+
+/**
+ * CLI critical path exporter
+ */
+public class LengthExport extends BasicCommand {
+    private final Argument<String> digFile;
+
+    /**
+     * Creates the critical path export command
+     */
+    public LengthExport() {
+        super("length");
+        digFile = addArgument(new Argument<>("dig", "", false));
+    }
+
+    @Override
+    protected void execute() throws CLIException {
+        try {
+            Model model = new CircuitLoader(digFile.get()).createModel();
+            ModelAnalyser modelAnalyser = new ModelAnalyser(model);
+            PathLenAnalyser pathLenAnalyser = new PathLenAnalyser(modelAnalyser);
+            System.out.println(pathLenAnalyser.getMaxPathLen());
+        } catch (IOException | ElementNotFoundException | PinException | NodeException | BacktrackException
+                 | AnalyseException e) {
+            throw new CLIException(Lang.get("cli_errorComputingCriticalPath"), e);
+        }
+    }
+}

--- a/src/main/java/de/neemann/digital/cli/Main.java
+++ b/src/main/java/de/neemann/digital/cli/Main.java
@@ -20,6 +20,7 @@ public class Main extends Muxer {
         addCommand(new CommandLineTester.TestCommand());
         addCommand(new SVGExport());
         addCommand(new StatsExport());
+        addCommand(new LengthExport());
         addCommand(new Runner());
     }
 

--- a/src/main/resources/lang/lang_de.xml
+++ b/src/main/resources/lang/lang_de.xml
@@ -1814,6 +1814,9 @@ Sind evtl. die Namen der Variablen nicht eindeutig?</string>
         Wenn diese Option fehlt, erfolgt eine Ausgabe auf die Konsole.
     </string>
     <string name="cli_errorCreatingStats">Fehler bei der Erzeugung der CSV Datei!</string>
+    <string name="cli_help_length">Gibt die Länge des kritischen Pfads der Schaltung aus.</string>
+    <string name="cli_help_length_dig">Name der Schaltungsdatei.</string>
+    <string name="cli_errorComputingCriticalPath">Fehler bei der Berechnung der kritischen Pfadlänge!</string>
 
     <string name="cli_run_noClock">Kein aktivierter Takt in der Schaltung gefunden!</string>
     <string name="cli_errorRunningCircuit">Fehler beim Starten der Schaltung!</string>

--- a/src/main/resources/lang/lang_en.xml
+++ b/src/main/resources/lang/lang_en.xml
@@ -1794,6 +1794,9 @@
         If this option is missing, the table is written to stdout.
     </string>
     <string name="cli_errorCreatingStats">Error while creating the stats file!</string>
+    <string name="cli_help_length">Prints the length of the critical path of the circuit.</string>
+    <string name="cli_help_length_dig">File name of the circuit.</string>
+    <string name="cli_errorComputingCriticalPath">Error while computing the critical path length!</string>
 
     <string name="cli_run_noClock">No running clock found in circuit!</string>
     <string name="cli_errorRunningCircuit">Error running the circuit!</string>

--- a/src/main/resources/lang/lang_es.xml
+++ b/src/main/resources/lang/lang_es.xml
@@ -2116,6 +2116,9 @@ Sin embargo, no se deben usar por encima de la línea del encabezado que contien
         Si no está indicada esta opción, se escribe la tabla en stdout.
     </string>
     <string name="cli_errorCreatingStats">Error al crear el archivo de estadísticas.</string>
+    <string name="cli_help_length">Imprime la longitud del camino crítico del circuito.</string>
+    <string name="cli_help_length_dig">Nombre del archivo del circuito.</string>
+    <string name="cli_errorComputingCriticalPath">Error al calcular la longitud del camino crítico.</string>
     <string name="menu_table_exportTablePlainText">Exporta texto plano</string>
     <string name="elem_ScopeTrigger">Gráfica de datos activos</string>
     <string name="elem_ScopeTrigger_short">Rango</string>

--- a/src/main/resources/lang/lang_es_ref.xml
+++ b/src/main/resources/lang/lang_es_ref.xml
@@ -2200,6 +2200,9 @@ However, they must not be used above the header line listing the signal names.&l
         If this option is missing, the table is written to stdout.
     </string>
     <string name="cli_errorCreatingStats">Error while creating the stats file!</string>
+    <string name="cli_help_length">Prints the length of the critical path of the circuit.</string>
+    <string name="cli_help_length_dig">File name of the circuit.</string>
+    <string name="cli_errorComputingCriticalPath">Error while computing the critical path length!</string>
     <string name="menu_table_exportTablePlainText">Export Plain Text</string>
     <string name="elem_ScopeTrigger">Triggered Data Graph</string>
     <string name="elem_ScopeTrigger_short">Scope</string>

--- a/src/main/resources/lang/lang_fr.xml
+++ b/src/main/resources/lang/lang_fr.xml
@@ -1789,6 +1789,9 @@ In the file howTo.md you can find more details about translations.
         Si cette option est manque, la table de vérité est écrite à la sortie standard.
     </string>
     <string name="cli_errorCreatingStats">Erreur lors de la création du fichier de statistiques!</string>
+    <string name="cli_help_length">Imprime la longueur du chemin critique du circuit.</string>
+    <string name="cli_help_length_dig">Nom de fichier du circuit.</string>
+    <string name="cli_errorComputingCriticalPath">Erreur lors du calcul de la longueur du chemin critique!</string>
     <string name="menu_window">Fenêtre</string>
     <string name="menu_about">À propos</string>
     <string name="menu_analyse">Analyse</string>

--- a/src/main/resources/lang/lang_fr_ref.xml
+++ b/src/main/resources/lang/lang_fr_ref.xml
@@ -1652,6 +1652,9 @@ In the file howTo.md you can find more details about translations.
         If this option is missing, the table is written to stdout.
     </string>
     <string name="cli_errorCreatingStats">Error while creating the stats file!</string>
+    <string name="cli_help_length">Prints the length of the critical path of the circuit.</string>
+    <string name="cli_help_length_dig">File name of the circuit.</string>
+    <string name="cli_errorComputingCriticalPath">Error while computing the critical path length!</string>
     <string name="menu_window">Windows</string>
     <string name="menu_about">About</string>
     <string name="menu_analyse">Analysis</string>

--- a/src/main/resources/lang/lang_it.xml
+++ b/src/main/resources/lang/lang_it.xml
@@ -1388,6 +1388,9 @@ In the file howTo.md you can find more details about translations.
     <string name="cli_help_stats_dig">Nome del file del circuito.</string>
     <string name="cli_help_stats_csv">Nome del file CSV da creare. Se questa opzione manca, la tabella è scritta nello standard output.</string>
     <string name="cli_errorCreatingStats">Errore durante la creazione dei file di statistica!</string>
+    <string name="cli_help_length">Stampa la lunghezza del cammino critico del circuito.</string>
+    <string name="cli_help_length_dig">Nome del file del circuito.</string>
+    <string name="cli_errorComputingCriticalPath">Errore durante il calcolo della lunghezza del cammino critico!</string>
     <string name="menu_window">Finestre</string>
     <string name="menu_about">Informazioni su</string>
     <string name="menu_analyse">Analisi</string>

--- a/src/main/resources/lang/lang_it_ref.xml
+++ b/src/main/resources/lang/lang_it_ref.xml
@@ -1439,6 +1439,9 @@ In the file howTo.md you can find more details about translations.
     <string name="cli_help_stats_csv">Name of the CSV file to be created.
         If this option is missing, the table is written to stdout.</string>
     <string name="cli_errorCreatingStats">Error while creating the stats file!</string>
+    <string name="cli_help_length">Prints the length of the critical path of the circuit.</string>
+    <string name="cli_help_length_dig">File name of the circuit.</string>
+    <string name="cli_errorComputingCriticalPath">Error while computing the critical path length!</string>
     <string name="menu_window">Windows</string>
     <string name="menu_about">About</string>
     <string name="menu_analyse">Analysis</string>

--- a/src/main/resources/lang/lang_pt.xml
+++ b/src/main/resources/lang/lang_pt.xml
@@ -2209,6 +2209,9 @@ In the file howTo.md you can find more details about translations.
         Se essa opção for omitida, a tabela será escrita na saída padrão.
     </string>
     <string name="cli_errorCreatingStats">Erro ao criar o arquivo com estatísticas!</string>
+    <string name="cli_help_length">Imprime o comprimento do caminho crítico do circuito.</string>
+    <string name="cli_help_length_dig">Nome do arquivo contendo circuito.</string>
+    <string name="cli_errorComputingCriticalPath">Erro no cálculo do comprimento do caminho crítico!</string>
     <string name="menu_table_exportTablePlainText">Exportar para texto puro</string>
     <string name="elem_StepperMotorBipolar_pin_A-">Bobina A, negativo</string>
     <string name="elem_StepperMotorBipolar_pin_B+">Bobina B, positivo</string>

--- a/src/main/resources/lang/lang_pt_ref.xml
+++ b/src/main/resources/lang/lang_pt_ref.xml
@@ -2250,6 +2250,9 @@ However, they must not be used above the header line listing the signal names.&l
         If this option is missing, the table is written to stdout.
     </string>
     <string name="cli_errorCreatingStats">Error while creating the stats file!</string>
+    <string name="cli_help_length">Prints the length of the critical path of the circuit.</string>
+    <string name="cli_help_length_dig">File name of the circuit.</string>
+    <string name="cli_errorComputingCriticalPath">Error while computing the critical path length!</string>
     <string name="menu_table_exportTablePlainText">Export Plain Text</string>
     <string name="elem_StepperMotorBipolar_pin_A-">Coil A, negative</string>
     <string name="elem_StepperMotorBipolar_pin_B+">Coil B, positive</string>

--- a/src/main/resources/lang/lang_zh.xml
+++ b/src/main/resources/lang/lang_zh.xml
@@ -1483,6 +1483,9 @@ In the file howTo.md you can find more details about translations.
     <string name="cli_help_stats_dig">电路文件名</string>
     <string name="cli_help_stats_csv">CSV 文件名，如果为空，将写入到标准输出。</string>
     <string name="cli_errorCreatingStats">创建统计文件时遇到错误！</string>
+    <string name="cli_help_length">打印电路关键路径的长度。</string>
+    <string name="cli_help_length_dig">电路文件名.</string>
+    <string name="cli_errorComputingCriticalPath">计算关键路径长度时出错!</string>
     <string name="menu_table_exportTablePlainText">导出纯文本</string>
     <string name="elem_ScopeTrigger">示波器</string>
     <string name="elem_ScopeTrigger_short">Scope</string>

--- a/src/main/resources/lang/lang_zh_ref.xml
+++ b/src/main/resources/lang/lang_zh_ref.xml
@@ -1866,6 +1866,9 @@ In the file howTo.md you can find more details about translations.
         If this option is missing, the table is written to stdout.
     </string>
     <string name="cli_errorCreatingStats">Error while creating the stats file!</string>
+    <string name="cli_help_length">Prints the length of the critical path of the circuit.</string>
+    <string name="cli_help_length_dig">File name of the circuit.</string>
+    <string name="cli_errorComputingCriticalPath">Error while computing the critical path length!</string>
     <string name="menu_table_exportTablePlainText">Export Plain Text</string>
     <string name="elem_ScopeTrigger">Triggered Data Graph</string>
     <string name="elem_ScopeTrigger_short">Scope</string>

--- a/src/test/java/de/neemann/digital/cli/LengthExportTest.java
+++ b/src/test/java/de/neemann/digital/cli/LengthExportTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025 Alessandro Pellegrini.
+ * Use of this source code is governed by the GPL v3 license
+ * that can be found in the LICENSE file.
+ */
+package de.neemann.digital.cli;
+
+import de.neemann.digital.cli.cli.CLIException;
+import de.neemann.digital.integration.Resources;
+import junit.framework.TestCase;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+
+public class LengthExportTest extends TestCase {
+
+    public void testLength() throws CLIException {
+        File source = new File(Resources.getRoot(), "../../main/dig/combinatorial/FullAdder.dig");
+        PrintStream old = System.out;
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try (PrintStream out = new PrintStream(baos)) {
+                System.setOut(out);
+                new LengthExport().execute(new String[]{source.getPath()});
+            }
+            String outStr = baos.toString();
+            assertEquals("3", outStr.replaceAll("\\R", ""));
+        } finally {
+            System.setOut(old);
+        }
+    }
+
+}


### PR DESCRIPTION
This commit introduces the CLI length command, that allows to print the critical path of the circuit from command line.

I have used this new CLI command for the past year in a GitHub Classroom workflow to pre-assess the complexity of some circuits that my students were desigining. I think it may a useful addition upstream, to let other people use it.

It is essentially based on the StatsExport CLI command, so it can be used as:

```bash
java -cp Digital.jar CLI length -dig circuit.dig
```

I hope the contribution is up to standards, if not, please let me know how I can improve it.